### PR TITLE
Add themed web client for DMUD

### DIFF
--- a/internal/net/server.go
+++ b/internal/net/server.go
@@ -175,9 +175,7 @@ func (s *Server) runWebSocketServer() {
 
 			s.game.AddPlayerChan <- client
 		})
-		mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-			_, _ = w.Write([]byte("DMUD up. Connect via wss://" + r.Host + "/ws\n"))
-		})
+		mux.Handle("/", s.webFileServer())
 		s.wsMux = mux
 	})
 

--- a/internal/net/web/client.js
+++ b/internal/net/web/client.js
@@ -1,0 +1,270 @@
+import { setupThemeSync } from "./theme.js";
+
+const RECONNECT_DELAY_MS = 4000;
+const MAX_LINES = 1200;
+const CLEAR_COMMANDS = new Set(["/clear", ":clear"]);
+
+const outputEl = document.querySelector('[data-role="output"]');
+const statusBadge = document.querySelector('[data-role="status"]');
+const hostEl = document.querySelector('[data-role="host"]');
+const reconnectButton = document.querySelector('[data-action="reconnect"]');
+const form = document.querySelector('[data-role="form"]');
+const input = document.querySelector('[data-role="input"]');
+const sendButton = document.querySelector('.command-bar__send');
+
+const params = new URLSearchParams(window.location.search);
+const websocketUrl = resolveWebSocketUrl(params);
+
+hostEl.textContent = websocketUrl;
+
+const history = [];
+let historyIndex = -1;
+let socket;
+let reconnectTimer = null;
+let isManuallyClosed = false;
+let queuedCommands = [];
+
+setupThemeSync();
+updateStatus("connecting");
+connect();
+
+reconnectButton.addEventListener("click", () => {
+  isManuallyClosed = false;
+  clearTimeout(reconnectTimer);
+  reconnectTimer = null;
+  connect(true);
+});
+
+form.addEventListener("submit", (event) => {
+  event.preventDefault();
+  const value = input.value;
+  if (!value.trim()) {
+    return;
+  }
+  if (CLEAR_COMMANDS.has(value.trim().toLowerCase())) {
+    clearOutput();
+    appendSystemLine("Cleared output.");
+    input.value = "";
+    history.push(value);
+    historyIndex = history.length;
+    return;
+  }
+  sendCommand(value);
+  input.value = "";
+  history.push(value);
+  historyIndex = history.length;
+});
+
+input.addEventListener("keydown", (event) => {
+  if (event.key === "ArrowUp") {
+    event.preventDefault();
+    navigateHistory(-1);
+  } else if (event.key === "ArrowDown") {
+    event.preventDefault();
+    navigateHistory(1);
+  } else if (event.key === "Escape") {
+    input.value = "";
+  }
+});
+
+function resolveWebSocketUrl(searchParams) {
+  const explicitWs = searchParams.get("ws") || searchParams.get("endpoint");
+  if (explicitWs) {
+    return explicitWs;
+  }
+  const host = searchParams.get("host");
+  const path = searchParams.get("path") || "/ws";
+  const protocol = window.location.protocol === "https:" ? "wss" : "ws";
+  if (host) {
+    return `${protocol}://${host}${path.startsWith("/") ? path : `/${path}`}`;
+  }
+  return `${protocol}://${window.location.host}${path}`;
+}
+
+function connect(isReconnect = false) {
+  updateStatus("connecting");
+  disableInput(true);
+  try {
+    socket = new WebSocket(websocketUrl);
+  } catch (error) {
+    appendSystemLine("Failed to create WebSocket connection.");
+    scheduleReconnect();
+    return;
+  }
+
+  socket.addEventListener("open", () => {
+    updateStatus("connected");
+    disableInput(false);
+    if (queuedCommands.length > 0) {
+      const pending = [...queuedCommands];
+      queuedCommands = [];
+      for (const command of pending) {
+        socket.send(command);
+      }
+    }
+    if (isReconnect) {
+      appendSystemLine("Reconnected to the server.");
+    }
+  });
+
+  socket.addEventListener("close", (event) => {
+    disableInput(true);
+    updateStatus(event.wasClean ? "disconnected" : "error");
+    if (!isManuallyClosed) {
+      scheduleReconnect();
+    }
+  });
+
+  socket.addEventListener("error", () => {
+    updateStatus("error");
+  });
+
+  socket.addEventListener("message", (event) => {
+    appendMessage(event.data);
+  });
+}
+
+function sendCommand(command) {
+  if (!socket || socket.readyState !== WebSocket.OPEN) {
+    appendSystemLine("Not connected. Queuing command.");
+    queuedCommands.push(command);
+    scheduleReconnect();
+    return;
+  }
+  try {
+    socket.send(command);
+  } catch (error) {
+    appendSystemLine("Failed to send command. Retrying soon.");
+    queuedCommands.push(command);
+    if (socket.readyState !== WebSocket.CONNECTING) {
+      scheduleReconnect();
+    }
+  }
+}
+
+function appendMessage(rawMessage) {
+  if (typeof rawMessage !== "string") {
+    return;
+  }
+  const text = rawMessage.replace(/\r\n?/g, "\n");
+  const segments = text.split("\n");
+  const shouldScroll = nearBottom();
+
+  for (const segment of segments) {
+    if (segment === "" && !outputEl.children.length) {
+      continue;
+    }
+    const line = document.createElement("div");
+    line.className = "line";
+    if (segment.trim().length === 0) {
+      line.classList.add("line--blank");
+    } else {
+      line.textContent = segment;
+    }
+    outputEl.appendChild(line);
+  }
+
+  while (outputEl.children.length > MAX_LINES) {
+    outputEl.removeChild(outputEl.firstChild);
+  }
+
+  if (shouldScroll) {
+    scrollToBottom();
+  }
+}
+
+function appendSystemLine(message) {
+  const shouldScroll = nearBottom();
+  const line = document.createElement("div");
+  line.className = "line line--system";
+  line.textContent = message;
+  outputEl.appendChild(line);
+  if (outputEl.children.length > MAX_LINES) {
+    outputEl.removeChild(outputEl.firstChild);
+  }
+  if (shouldScroll) {
+    scrollToBottom();
+  }
+}
+
+function clearOutput() {
+  outputEl.innerHTML = "";
+}
+
+function nearBottom() {
+  return outputEl.scrollHeight - outputEl.scrollTop - outputEl.clientHeight < 24;
+}
+
+function scrollToBottom() {
+  outputEl.scrollTop = outputEl.scrollHeight;
+}
+
+function scheduleReconnect() {
+  if (reconnectTimer) {
+    return;
+  }
+  reconnectTimer = window.setTimeout(() => {
+    reconnectTimer = null;
+    if (!isManuallyClosed) {
+      connect(true);
+    }
+  }, RECONNECT_DELAY_MS);
+}
+
+function disableInput(disabled) {
+  input.disabled = disabled;
+  if (sendButton) {
+    sendButton.disabled = disabled;
+    sendButton.setAttribute("aria-disabled", String(disabled));
+  }
+}
+
+function updateStatus(state) {
+  statusBadge.dataset.status = state;
+  switch (state) {
+    case "connected":
+      statusBadge.textContent = "Connected";
+      break;
+    case "connecting":
+      statusBadge.textContent = "Connecting…";
+      break;
+    case "error":
+      statusBadge.textContent = "Connection issue";
+      break;
+    default:
+      statusBadge.textContent = "Disconnected";
+      break;
+  }
+}
+
+function navigateHistory(direction) {
+  if (!history.length) {
+    return;
+  }
+  if (historyIndex === -1) {
+    historyIndex = history.length;
+  }
+  historyIndex += direction;
+  if (historyIndex < 0) {
+    historyIndex = 0;
+  } else if (historyIndex > history.length) {
+    historyIndex = history.length;
+  }
+  if (historyIndex === history.length) {
+    input.value = "";
+    return;
+  }
+  input.value = history[historyIndex] ?? "";
+  window.requestAnimationFrame(() => {
+    input.setSelectionRange(input.value.length, input.value.length);
+  });
+}
+
+window.addEventListener("beforeunload", () => {
+  isManuallyClosed = true;
+  clearTimeout(reconnectTimer);
+  reconnectTimer = null;
+  if (socket && socket.readyState === WebSocket.OPEN) {
+    socket.close(1000, "Page unloading");
+  }
+});

--- a/internal/net/web/index.html
+++ b/internal/net/web/index.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>DMUD</title>
+  <link rel="stylesheet" href="./styles.css">
+</head>
+<body>
+  <div class="page" id="app">
+    <header class="header">
+      <div class="header__status">
+        <span class="status-badge" data-role="status">Connecting…</span>
+        <span class="status-host" data-role="host"></span>
+      </div>
+      <div class="header__actions">
+        <button class="ghost-button" type="button" data-action="reconnect" title="Reconnect to the server">Reconnect</button>
+      </div>
+    </header>
+
+    <main class="shell" data-role="output" aria-live="polite" aria-atomic="false"></main>
+
+    <form class="command-bar" data-role="form" autocomplete="off">
+      <label class="sr-only" for="command-input">Command input</label>
+      <input id="command-input" class="command-bar__input" data-role="input" type="text"
+             spellcheck="false" autocapitalize="none" autocomplete="off" autofocus
+             placeholder="Type a command and press Enter">
+      <button class="command-bar__send" type="submit">Send</button>
+    </form>
+
+    <p class="hint" data-role="hint">Type <code>/clear</code> to clear the log or <code>help</code> for in-game help.</p>
+  </div>
+
+  <script type="module" src="./client.js"></script>
+</body>
+</html>

--- a/internal/net/web/styles.css
+++ b/internal/net/web/styles.css
@@ -1,0 +1,274 @@
+:root {
+  color-scheme: dark;
+  --mud-font-stack: "JetBrains Mono", "Fira Code", "SFMono-Regular", "Consolas", "Liberation Mono", "Menlo", monospace;
+  --mud-bg: #0f0f10;
+  --mud-surface: #151517;
+  --mud-border: #1f2024;
+  --mud-text: #f5f6f7;
+  --mud-subtle-text: #a1a7b3;
+  --mud-accent: #f97316;
+  --mud-accent-text: #0b0c0f;
+  --mud-success: #16a34a;
+  --mud-error: #ef4444;
+  --mud-scroll-track: color-mix(in srgb, var(--mud-surface) 80%, #000 20%);
+  --mud-scroll-thumb: color-mix(in srgb, var(--mud-border) 70%, var(--mud-accent) 30%);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  height: 100%;
+}
+
+body {
+  margin: 0;
+  font-family: var(--mud-font-stack);
+  font-size: 15px;
+  line-height: 1.5;
+  background-color: var(--mud-bg);
+  color: var(--mud-text);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(1.25rem, 4vw, 2.5rem);
+}
+
+.page {
+  display: flex;
+  flex-direction: column;
+  width: min(960px, 100%);
+  gap: 1rem;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.header__status {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.status-badge {
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.3rem 0.85rem;
+  border-radius: 9999px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  background-color: var(--mud-border);
+  color: var(--mud-subtle-text);
+  transition: background-color 180ms ease, color 180ms ease;
+}
+
+.status-badge[data-status="connected"] {
+  background-color: var(--mud-success);
+  color: var(--mud-accent-text);
+}
+
+.status-badge[data-status="error"] {
+  background-color: var(--mud-error);
+  color: var(--mud-accent-text);
+}
+
+.status-host {
+  color: var(--mud-subtle-text);
+  font-size: 0.8rem;
+  word-break: break-all;
+}
+
+.header__actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.ghost-button {
+  appearance: none;
+  border: 1px solid var(--mud-border);
+  background: transparent;
+  color: var(--mud-text);
+  font-family: inherit;
+  font-size: 0.9rem;
+  padding: 0.4rem 0.85rem;
+  border-radius: 0.5rem;
+  cursor: pointer;
+  transition: border-color 180ms ease, color 180ms ease, background-color 180ms ease;
+}
+
+.ghost-button:hover,
+.ghost-button:focus-visible {
+  border-color: var(--mud-accent);
+  color: var(--mud-accent);
+  outline: none;
+}
+
+.shell {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 1rem;
+  border-radius: 0.75rem;
+  background: var(--mud-surface);
+  border: 1px solid var(--mud-border);
+  min-height: clamp(320px, 55vh, 600px);
+  max-height: 70vh;
+  overflow-y: auto;
+  font-size: 0.95rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+  scrollbar-color: var(--mud-scroll-thumb) var(--mud-scroll-track);
+}
+
+.shell::-webkit-scrollbar {
+  width: 0.6rem;
+}
+
+.shell::-webkit-scrollbar-track {
+  background: var(--mud-scroll-track);
+  border-radius: 9999px;
+}
+
+.shell::-webkit-scrollbar-thumb {
+  background: var(--mud-scroll-thumb);
+  border-radius: 9999px;
+}
+
+.line {
+  font-variant-ligatures: none;
+}
+
+.line--blank::before {
+  content: "\00a0";
+}
+
+.line--system {
+  color: var(--mud-subtle-text);
+}
+
+.command-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: var(--mud-surface);
+  border: 1px solid var(--mud-border);
+  border-radius: 0.75rem;
+  padding: 0.35rem;
+}
+
+.command-bar__input {
+  flex: 1;
+  background: transparent;
+  border: none;
+  color: var(--mud-text);
+  font: inherit;
+  padding: 0.4rem 0.65rem;
+  min-width: 0;
+}
+
+.command-bar__input:focus {
+  outline: none;
+}
+
+.command-bar__send {
+  appearance: none;
+  border: none;
+  background: var(--mud-accent);
+  color: var(--mud-accent-text);
+  font: inherit;
+  font-weight: 600;
+  padding: 0.45rem 1rem;
+  border-radius: 0.6rem;
+  cursor: pointer;
+  transition: filter 180ms ease, transform 180ms ease;
+}
+
+.command-bar__send:disabled,
+.command-bar__send[aria-disabled="true"] {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.command-bar__send:hover:not(:disabled),
+.command-bar__send:focus-visible:not(:disabled) {
+  outline: none;
+  filter: brightness(1.1);
+}
+
+.command-bar__send:active:not(:disabled) {
+  transform: translateY(1px);
+}
+
+.hint {
+  margin: 0;
+  color: var(--mud-subtle-text);
+  font-size: 0.8rem;
+}
+
+.hint code {
+  font-family: var(--mud-font-stack);
+  background: color-mix(in srgb, var(--mud-border) 70%, transparent);
+  padding: 0.1rem 0.35rem;
+  border-radius: 0.35rem;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+@media (max-width: 720px) {
+  body {
+    padding: 1rem;
+  }
+
+  .page {
+    gap: 0.75rem;
+  }
+
+  .header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .header__status {
+    width: 100%;
+  }
+
+  .header__actions {
+    width: 100%;
+    justify-content: flex-end;
+  }
+
+  .shell {
+    min-height: clamp(240px, 50vh, 540px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/internal/net/web/theme.js
+++ b/internal/net/web/theme.js
@@ -1,0 +1,264 @@
+const CSS_VAR_DEFAULTS = {
+  "--mud-bg": "#0f0f10",
+  "--mud-surface": "#151517",
+  "--mud-border": "#1f2024",
+  "--mud-text": "#f5f6f7",
+  "--mud-subtle-text": "#a1a7b3",
+  "--mud-accent": "#f97316",
+  "--mud-accent-text": "#0b0c0f",
+  "--mud-success": "#16a34a",
+  "--mud-error": "#ef4444",
+};
+
+const CSS_VAR_CANDIDATES = {
+  "--mud-bg": ["--mud-bg", "--bg", "--background", "--color-bg", "--surface-base"],
+  "--mud-surface": ["--mud-surface", "--surface", "--panel", "--surface-100", "--muted"],
+  "--mud-border": ["--mud-border", "--border", "--border-color", "--surface-200"],
+  "--mud-text": ["--mud-text", "--text", "--foreground", "--color-text"],
+  "--mud-subtle-text": ["--mud-subtle-text", "--muted-foreground", "--muted-text", "--text-muted", "--color-muted"],
+  "--mud-accent": ["--mud-accent", "--accent", "--primary", "--color-accent", "--brand"],
+  "--mud-accent-text": ["--mud-accent-text", "--accent-foreground", "--on-accent", "--color-on-accent"],
+  "--mud-success": ["--mud-success", "--success", "--color-success", "--green"],
+  "--mud-error": ["--mud-error", "--danger", "--color-danger", "--red"],
+};
+
+const PARAM_ALIASES = {
+  "--mud-bg": ["bg", "background"],
+  "--mud-surface": ["surface", "panel", "card"],
+  "--mud-border": ["border", "outline"],
+  "--mud-text": ["text", "fg", "foreground"],
+  "--mud-subtle-text": ["muted", "subtle", "fgMuted"],
+  "--mud-accent": ["accent", "primary", "highlight"],
+  "--mud-accent-text": ["accentText", "onAccent", "accent-foreground"],
+  "--mud-success": ["success"],
+  "--mud-error": ["error", "danger"],
+};
+
+const THEME_MESSAGE_TYPES = new Set([
+  "dmud:theme",
+  "dmud-theme",
+  "dmud:theme:update",
+]);
+
+function normaliseColor(value) {
+  if (!value) {
+    return "";
+  }
+  const trimmed = String(value).trim();
+  if (!trimmed) {
+    return "";
+  }
+  if (/^[0-9a-fA-F]{6}$/.test(trimmed)) {
+    return `#${trimmed}`;
+  }
+  if (/^[0-9a-fA-F]{3}$/.test(trimmed)) {
+    return `#${trimmed}`;
+  }
+  return trimmed;
+}
+
+function resolveCandidate(computed, candidates) {
+  for (const name of candidates) {
+    const value = computed.getPropertyValue(name).trim();
+    if (value) {
+      return value;
+    }
+  }
+  return "";
+}
+
+function applyCssVariables(root, values) {
+  if (!values) {
+    return;
+  }
+  for (const [key, value] of Object.entries(values)) {
+    if (typeof value === "string" && value.trim() !== "") {
+      root.style.setProperty(key, value.trim());
+    }
+  }
+}
+
+function parseMessageTheme(data) {
+  if (!data || typeof data !== "object") {
+    return { vars: {}, scheme: "" };
+  }
+
+  const theme = { vars: {}, scheme: "" };
+  const cssVars = data.cssVariables || data.css || data.vars;
+  if (cssVars && typeof cssVars === "object") {
+    for (const [key, value] of Object.entries(cssVars)) {
+      theme.vars[key] = normaliseColor(value);
+    }
+  }
+
+  const aliasToVar = {
+    bg: "--mud-bg",
+    background: "--mud-bg",
+    surface: "--mud-surface",
+    panel: "--mud-surface",
+    card: "--mud-surface",
+    border: "--mud-border",
+    outline: "--mud-border",
+    text: "--mud-text",
+    foreground: "--mud-text",
+    fg: "--mud-text",
+    muted: "--mud-subtle-text",
+    subtle: "--mud-subtle-text",
+    accent: "--mud-accent",
+    primary: "--mud-accent",
+    highlight: "--mud-accent",
+    accentText: "--mud-accent-text",
+    onAccent: "--mud-accent-text",
+    success: "--mud-success",
+    error: "--mud-error",
+    danger: "--mud-error",
+  };
+
+  for (const [key, cssVar] of Object.entries(aliasToVar)) {
+    if (key in data) {
+      theme.vars[cssVar] = normaliseColor(data[key]);
+    }
+  }
+
+  if (typeof data.colorScheme === "string") {
+    theme.scheme = data.colorScheme;
+  } else if (typeof data.scheme === "string") {
+    theme.scheme = data.scheme;
+  } else if (typeof data.mode === "string") {
+    theme.scheme = data.mode;
+  }
+
+  return theme;
+}
+
+function applyColorScheme(root, scheme) {
+  const value = typeof scheme === "string" ? scheme.trim().toLowerCase() : "";
+  if (!value) {
+    return;
+  }
+  if (value === "light" || value === "dark") {
+    root.style.colorScheme = value;
+    root.dataset.colorScheme = value;
+  }
+}
+
+export function setupThemeSync(options = {}) {
+  const root = document.documentElement;
+  const params = new URLSearchParams(window.location.search);
+  const requestParent = options.requestParent !== false;
+
+  function refreshFromComputed() {
+    const computed = getComputedStyle(root);
+    const updates = {};
+    for (const [cssVar, fallback] of Object.entries(CSS_VAR_DEFAULTS)) {
+      const candidates = CSS_VAR_CANDIDATES[cssVar] || [cssVar];
+      const value = resolveCandidate(computed, candidates) || fallback;
+      updates[cssVar] = value;
+    }
+    applyCssVariables(root, updates);
+  }
+
+  function applyFromParams() {
+    const updates = {};
+    for (const [cssVar, aliases] of Object.entries(PARAM_ALIASES)) {
+      for (const alias of aliases) {
+        if (params.has(alias)) {
+          updates[cssVar] = normaliseColor(params.get(alias));
+          break;
+        }
+      }
+    }
+    if (params.has("colorScheme")) {
+      applyColorScheme(root, params.get("colorScheme"));
+    } else if (params.has("scheme")) {
+      applyColorScheme(root, params.get("scheme"));
+    } else if (params.has("theme")) {
+      applyColorScheme(root, params.get("theme"));
+    }
+    applyCssVariables(root, updates);
+  }
+
+  function handleMessage(event) {
+    const data = event.data;
+    if (!data) {
+      return;
+    }
+    if (typeof data === "string") {
+      try {
+        const parsed = JSON.parse(data);
+        handleParsedMessage(parsed);
+        return;
+      } catch (_) {
+        return;
+      }
+    }
+    handleParsedMessage(data);
+  }
+
+  function handleParsedMessage(data) {
+    if (!data || typeof data !== "object") {
+      return;
+    }
+    const type = typeof data.type === "string" ? data.type : "";
+    if (THEME_MESSAGE_TYPES.has(type)) {
+      const payload = "theme" in data ? data.theme : data.payload || data;
+      const { vars, scheme } = parseMessageTheme(payload);
+      applyCssVariables(root, vars);
+      applyColorScheme(root, scheme);
+      return;
+    }
+    if (type === "dmud:theme:request") {
+      if (typeof options.onThemeRequest === "function") {
+        options.onThemeRequest();
+      }
+    }
+  }
+
+  function requestTheme() {
+    if (!requestParent) {
+      return;
+    }
+    if (window.parent && window.parent !== window) {
+      try {
+        window.parent.postMessage({ type: "dmud:request-theme" }, "*");
+      } catch (_) {
+        /* no-op */
+      }
+    }
+  }
+
+  refreshFromComputed();
+  applyFromParams();
+  if (requestParent) {
+    requestTheme();
+    window.setTimeout(requestTheme, 250);
+  }
+
+  window.addEventListener("message", handleMessage);
+  const mq = window.matchMedia("(prefers-color-scheme: dark)");
+  if (typeof mq.addEventListener === "function") {
+    mq.addEventListener("change", () => {
+      refreshFromComputed();
+    });
+  }
+
+  const observer = new MutationObserver((mutations) => {
+    for (const mutation of mutations) {
+      if (mutation.type === "attributes") {
+        refreshFromComputed();
+        break;
+      }
+    }
+  });
+  observer.observe(root, { attributes: true, attributeFilter: ["class", "data-theme", "data-color-mode"] });
+
+  return {
+    applyUpdate: (update) => {
+      const { vars, scheme } = parseMessageTheme(update);
+      applyCssVariables(root, vars);
+      applyColorScheme(root, scheme);
+    },
+    refreshFromComputed,
+    requestTheme,
+  };
+}

--- a/internal/net/web_assets.go
+++ b/internal/net/web_assets.go
@@ -1,0 +1,41 @@
+package net
+
+import (
+	"embed"
+	"io/fs"
+	"net/http"
+	"path"
+	"strings"
+)
+
+//go:embed web/*
+var webFS embed.FS
+
+func (s *Server) webFileServer() http.Handler {
+	root, err := fs.Sub(webFS, "web")
+	if err != nil {
+		// this should never happen; panic to surface configuration issue
+		panic(err)
+	}
+	fileServer := http.FileServer(http.FS(root))
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Ensure we always serve index.html for the root path
+		if r.URL.Path == "" || r.URL.Path == "/" {
+			r = r.Clone(r.Context())
+			r.URL.Path = "/index.html"
+		}
+
+		// Prevent directory traversal
+		if strings.Contains(r.URL.Path, "..") {
+			http.NotFound(w, r)
+			return
+		}
+
+		// Ensure consistent content type for JS modules
+		if ext := path.Ext(r.URL.Path); ext == ".js" {
+			w.Header().Set("Content-Type", "application/javascript")
+		}
+		w.Header().Set("Cache-Control", "public, max-age=60")
+		fileServer.ServeHTTP(w, r)
+	})
+}


### PR DESCRIPTION
## Summary
- embed a browser client with history, reconnect handling, and `/clear` support
- sync the client palette with blog theme variables, query params, and `postMessage`
- serve the embedded static assets from the Go server so `/` hosts the new UI

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d0a0af4a8c832085bf95fd1a749ce5