### PR TITLE
Adjust newline handling for client output

### DIFF
--- a/internal/game/game.go
+++ b/internal/game/game.go
@@ -323,7 +323,7 @@ func (g *Game) HandleConnect(c common.Client) {
 	if c.SupportsPrompt() {
 		c.SendMessage("> ")
 	} else {
-		c.SendMessage("") // spacer after the welcome text
+		c.SendMessage("\n") // spacer after the welcome text
 	}
 
 	go c.HandleRequest()

--- a/internal/net/tcp_client.go
+++ b/internal/net/tcp_client.go
@@ -67,7 +67,7 @@ func (c *TCPClient) RemoteAddr() string {
 }
 
 func (c *TCPClient) SendMessage(msg string) {
-	if !strings.HasSuffix(msg, "\n") {
+	if strings.Contains(msg, "\n") && !strings.HasSuffix(msg, "\n") {
 		msg += "\n"
 	}
 	_, err := c.conn.Write([]byte(msg))

--- a/internal/net/ws_client.go
+++ b/internal/net/ws_client.go
@@ -160,11 +160,13 @@ func (c *WSClient) RemoteAddr() string {
 
 func (c *WSClient) SendMessage(msg string) {
 	s := msg
-	if !strings.HasPrefix(s, "\n") {
-		s = "\n" + s
-	}
-	if !strings.HasSuffix(s, "\n") {
-		s = s + "\n"
+	if strings.Contains(s, "\n") {
+		if !strings.HasPrefix(s, "\n") {
+			s = "\n" + s
+		}
+		if !strings.HasSuffix(s, "\n") {
+			s = s + "\n"
+		}
 	}
 
 	c.writeMu.Lock()


### PR DESCRIPTION
## Summary
- add trailing newlines to TCP output only when messages contain line breaks
- only wrap websocket messages with surrounding newlines for multi-line payloads
- send an explicit spacer newline for non-prompt clients after the welcome banner

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d0c6d76a9083209b645173c4bd65ff