### PR TITLE
Trim WebSocket broadcasts to avoid double spacing

### DIFF
--- a/internal/components/player.go
+++ b/internal/components/player.go
@@ -21,7 +21,21 @@ type Player struct {
 }
 
 func (p *Player) Broadcast(m string) {
-	p.Client.SendMessage(m)
+	msg := m
+
+	if !p.Client.SupportsPrompt() {
+		trimmed := strings.TrimLeft(msg, "\n")
+
+		switch {
+		case trimmed == "" && strings.Contains(msg, "\n"):
+			// Preserve intentional blank lines but collapse multiples to one.
+			msg = "\n"
+		case trimmed != "":
+			msg = trimmed
+		}
+	}
+
+	p.Client.SendMessage(msg)
 }
 
 // Update the Player Look method


### PR DESCRIPTION
## Summary
- trim leading newlines before sending messages to WebSocket clients so NPC emotes no longer add blank rows

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d0d3aed3108320979b090e43eeb236