### PR TITLE
Allow websocket connections from dusty-wtf.pages.dev subdomains

### DIFF
--- a/internal/net/ws_client.go
+++ b/internal/net/ws_client.go
@@ -47,6 +47,9 @@ var upgrader = websocket.Upgrader{
 		if oh == "dusty.wtf" {
 			return true
 		}
+		if oh == "dusty-wtf.pages.dev" || strings.HasSuffix(oh, ".dusty-wtf.pages.dev") {
+			return true
+		}
 		log.Info().Msgf("Rejected Origin %s for host %s", oh, rh)
 		return false
 	},


### PR DESCRIPTION
## Summary
- allow websocket origins from dusty-wtf.pages.dev and its subdomains so the Pages front-end can connect

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d1169b418c8320b6ff35af73fbfe8f