### PR TITLE
Refactor rooms into areas with region support

### DIFF
--- a/internal/components/npc.go
+++ b/internal/components/npc.go
@@ -9,25 +9,25 @@ import (
 )
 
 type NPC struct {
-    sync.RWMutex
+	sync.RWMutex
 
-    Name        string
-    Description string
-    Room        *Room
-    TemplateID  string
-    Behavior    NPCBehavior
-    Dialogue    []string
-    LastAction  time.Time
-    Target      common.EntityID // For aggressive NPCs
+	Name        string
+	Description string
+	Area        *Area
+	TemplateID  string
+	Behavior    NPCBehavior
+	Dialogue    []string
+	LastAction  time.Time
+	Target      common.EntityID // For aggressive NPCs
 }
 
 func (n *NPC) GetRandomDialogue() string {
-    n.RLock()
-    defer n.RUnlock()
+	n.RLock()
+	defer n.RUnlock()
 
-    if len(n.Dialogue) == 0 {
-        return ""
-    }
+	if len(n.Dialogue) == 0 {
+		return ""
+	}
 
-    return n.Dialogue[rand.Intn(len(n.Dialogue))]
+	return n.Dialogue[rand.Intn(len(n.Dialogue))]
 }

--- a/internal/components/player.go
+++ b/internal/components/player.go
@@ -14,7 +14,7 @@ type Player struct {
 	Client common.Client
 
 	Name string
-	Room *Room
+	Area *Area
 
 	// Command history and auto-complete
 	CommandHistory *CommandHistory
@@ -27,29 +27,32 @@ func (p *Player) Broadcast(msg string) {
 
 // Update the Player Look method
 func (p *Player) Look(w WorldLike) {
-	if p.Room == nil {
+	if p.Area == nil {
 		p.Broadcast("You are nowhere.")
 		return
 	}
 
-	// Room description
-	p.Broadcast(p.Room.Description + "\n")
+	// Area description
+	p.Broadcast(p.Area.Description + "\n")
+	if p.Area.Region != "" {
+		p.Broadcast("Region: " + p.Area.Region)
+	}
 
 	// Show other players
-	p.Room.PlayersMutex.RLock()
+	p.Area.PlayersMutex.RLock()
 	var otherPlayers []string
-	for _, player := range p.Room.Players {
+	for _, player := range p.Area.Players {
 		if player != p {
 			otherPlayers = append(otherPlayers, player.Name)
 		}
 	}
-	p.Room.PlayersMutex.RUnlock()
+	p.Area.PlayersMutex.RUnlock()
 	for _, name := range otherPlayers {
 		p.Broadcast(name + " is here.")
 	}
 
 	// Show NPCs after players
-	npcs := p.Room.GetNPCs(w)
+	npcs := p.Area.GetNPCs(w)
 	for _, npc := range npcs {
 		p.Broadcast(npc.Name + " is here.")
 	}
@@ -57,9 +60,9 @@ func (p *Player) Look(w WorldLike) {
 	p.Broadcast("\n")
 
 	// Show exits
-	if len(p.Room.Exits) > 0 {
-		exits := make([]string, len(p.Room.Exits))
-		for i, exit := range p.Room.Exits {
+	if len(p.Area.Exits) > 0 {
+		exits := make([]string, len(p.Area.Exits))
+		for i, exit := range p.Area.Exits {
 			exits[i] = exit.Direction
 		}
 		p.Broadcast(fmt.Sprintf("\n\nExits: [%s]", strings.Join(exits, ", ")))

--- a/internal/components/spawn.go
+++ b/internal/components/spawn.go
@@ -10,34 +10,34 @@ import (
 type SpawnType int
 
 const (
-    SpawnTypeNPC SpawnType = iota
-    SpawnTypeItem
-    SpawnTypeResource
+	SpawnTypeNPC SpawnType = iota
+	SpawnTypeItem
+	SpawnTypeResource
 )
 
 type SpawnConfig struct {
-    Type        SpawnType
-    TemplateID  string      // ID of the NPC template to spawn
-    MinCount    int         // Minimum number to maintain
-    MaxCount    int         // Maximum number allowed
-    RespawnTime time.Duration // Time before respawning
-    Chance      float64     // Spawn chance (0.0 to 1.0)
+	Type        SpawnType
+	TemplateID  string        // ID of the NPC template to spawn
+	MinCount    int           // Minimum number to maintain
+	MaxCount    int           // Maximum number allowed
+	RespawnTime time.Duration // Time before respawning
+	Chance      float64       // Spawn chance (0.0 to 1.0)
 }
 
 type Spawn struct {
-    sync.RWMutex
+	sync.RWMutex
 
-    Configs      []SpawnConfig
-    ActiveSpawns map[string]common.EntityID // templateID -> entityIDs
-    LastSpawn    time.Time
-    RoomID       common.EntityID
+	Configs      []SpawnConfig
+	ActiveSpawns map[string]common.EntityID // templateID -> entityIDs
+	LastSpawn    time.Time
+	AreaID       common.EntityID
 }
 
-func NewSpawn(roomID common.EntityID) *Spawn {
-    return &Spawn{
-        Configs:      make([]SpawnConfig, 0),
-        ActiveSpawns: make(map[string]common.EntityID),
-        RoomID:       roomID,
-        LastSpawn:    time.Now(),
-    }
+func NewSpawn(areaID common.EntityID) *Spawn {
+	return &Spawn{
+		Configs:      make([]SpawnConfig, 0),
+		ActiveSpawns: make(map[string]common.EntityID),
+		AreaID:       areaID,
+		LastSpawn:    time.Now(),
+	}
 }

--- a/internal/game/chat.go
+++ b/internal/game/chat.go
@@ -15,7 +15,7 @@ func handleSay(player *components.Player, args []string, game *Game) {
 		return
 	}
 	player.Broadcast("You say: " + msg) // echo to speaker
-	player.Room.Broadcast(fmt.Sprintf("%s says: %s", player.Name, msg), player)
+	player.Area.Broadcast(fmt.Sprintf("%s says: %s", player.Name, msg), player)
 }
 
 func handleShout(player *components.Player, args []string, game *Game) {
@@ -31,7 +31,7 @@ func (g *Game) HandleShout(player *components.Player, msg string) {
 	player.RWMutex.RLock()
 	defer player.RWMutex.RUnlock()
 
-	if player.Room == nil {
+	if player.Area == nil {
 		player.Broadcast("You shout but there is no sound.")
 		return
 	}
@@ -39,26 +39,26 @@ func (g *Game) HandleShout(player *components.Player, msg string) {
 
 	depth := 10
 
-	visited := make(map[*components.Room]bool)
-	queue := []*components.Room{player.Room}
+	visited := make(map[*components.Area]bool)
+	queue := []*components.Area{player.Area}
 
 	for depth > 0 && len(queue) > 0 {
 		depth--
-		nextQueue := []*components.Room{}
+		nextQueue := []*components.Area{}
 
-		for _, room := range queue {
-			visited[room] = true
-			for _, exit := range room.Exits {
-				if !visited[exit.Room] {
-					visited[exit.Room] = true
-					nextQueue = append(nextQueue, exit.Room)
+		for _, area := range queue {
+			visited[area] = true
+			for _, exit := range area.Exits {
+				if !visited[exit.Area] {
+					visited[exit.Area] = true
+					nextQueue = append(nextQueue, exit.Area)
 				}
 			}
 		}
 		queue = nextQueue
 	}
 
-	for room := range visited {
-		room.Broadcast(fmt.Sprintf("%s shouts: %s", player.Name, msg), player)
+	for area := range visited {
+		area.Broadcast(fmt.Sprintf("%s shouts: %s", player.Name, msg), player)
 	}
 }

--- a/internal/game/combat.go
+++ b/internal/game/combat.go
@@ -25,13 +25,13 @@ func (g *Game) HandleKill(player *components.Player, targetName string) {
 	// First check for players
 	g.playersMu.Lock()
 	defer g.playersMu.Unlock()
-	
+
 	targetEntity := g.players[targetName]
 	playerEntity := g.players[player.Name]
 
 	if targetEntity == nil {
 		// Check for NPCs
-		npcs := player.Room.GetNPCs(g.world.AsWorldLike())
+		npcs := player.Area.GetNPCs(g.world.AsWorldLike())
 		for _, npc := range npcs {
 			if strings.Contains(strings.ToLower(npc.Name), strings.ToLower(targetName)) {
 				// Find NPC entity
@@ -68,6 +68,6 @@ func (g *Game) HandleKill(player *components.Player, targetName string) {
 
 	// Announce combat
 	if npc, err := ecs.GetTypedComponent[*components.NPC](g.world, targetEntity.ID, "NPC"); err == nil {
-		player.Room.Broadcast(player.Name + " attacks " + npc.Name + "!")
+		player.Area.Broadcast(player.Name + " attacks " + npc.Name + "!")
 	}
 }

--- a/internal/game/commands.go
+++ b/internal/game/commands.go
@@ -86,8 +86,8 @@ func handleHelp(player *components.Player, args []string, game *Game) {
 		b.WriteString("Basic Commands:\n")
 		b.WriteString("  look          - Look around your current location\n")
 		b.WriteString("  who            - List online players\n")
-		b.WriteString("  say <message>  - Say something to players in the same room\n")
-		b.WriteString("  shout <message> - Shout to nearby rooms\n")
+		b.WriteString("  say <message>  - Say something to players in the same area\n")
+		b.WriteString("  shout <message> - Shout to nearby areas\n")
 		b.WriteString("  examine <target> - Examine something or someone\n")
 		b.WriteString("  kill <target>  - Attack a player or NPC\n")
 		b.WriteString("  exit           - Leave the game\n")
@@ -125,19 +125,19 @@ func handleHelp(player *components.Player, args []string, game *Game) {
 
 	// Define command help
 	commandHelp := map[string]string{
-		"look":     "Look around your current location to see the room description, exits, and other players/NPCs present.",
+		"look":     "Look around your current location to see the area description, exits, and other players/NPCs present.",
 		"who":      "List all players currently online in the game.",
-		"say":      "Say something to all players in the same room. Usage: say <message>",
-		"shout":    "Shout a message that can be heard in nearby rooms. Usage: shout <message>",
+		"say":      "Say something to all players in the same area. Usage: say <message>",
+		"shout":    "Shout a message that can be heard in nearby areas. Usage: shout <message>",
 		"examine":  "Examine something or someone in detail. Usage: examine <target>",
 		"kill":     "Attack another player or NPC. Usage: kill <target>",
 		"exit":     "Leave the game and disconnect from the server.",
-		"north":    "Move north to the adjacent room (if an exit exists).",
-		"south":    "Move south to the adjacent room (if an exit exists).",
-		"east":     "Move east to the adjacent room (if an exit exists).",
-		"west":     "Move west to the adjacent room (if an exit exists).",
-		"up":       "Move up to the adjacent room (if an exit exists).",
-		"down":     "Move down to the adjacent room (if an exit exists).",
+		"north":    "Move north to the adjacent area (if an exit exists).",
+		"south":    "Move south to the adjacent area (if an exit exists).",
+		"east":     "Move east to the adjacent area (if an exit exists).",
+		"west":     "Move west to the adjacent area (if an exit exists).",
+		"up":       "Move up to the adjacent area (if an exit exists).",
+		"down":     "Move down to the adjacent area (if an exit exists).",
 		"name":     "Change your player name. Usage: name <new_name>",
 		"help":     "Show help information. Usage: help [command]",
 		"history":  "Show your command history (last 100 commands).",

--- a/internal/game/misc.go
+++ b/internal/game/misc.go
@@ -93,8 +93,8 @@ func handleExamine(player *components.Player, args []string, game *Game) {
 
 	target := strings.Join(args, " ")
 
-	// Check for NPCs in the room
-	npcs := player.Room.GetNPCs(game.world.AsWorldLike())
+	// Check for NPCs in the area
+	npcs := player.Area.GetNPCs(game.world.AsWorldLike())
 	for _, npc := range npcs {
 		if strings.Contains(strings.ToLower(npc.Name), strings.ToLower(target)) {
 			player.Broadcast(npc.Description)
@@ -136,7 +136,7 @@ func handleExamine(player *components.Player, args []string, game *Game) {
 	}
 
 	// Check for players
-	targetPlayer := player.Room.GetPlayer(target)
+	targetPlayer := player.Area.GetPlayer(target)
 	if targetPlayer != nil {
 		player.Broadcast("You see " + targetPlayer.Name + ", a fellow adventurer.")
 		return

--- a/internal/systems/ai.go
+++ b/internal/systems/ai.go
@@ -73,15 +73,15 @@ func (as *AISystem) processAggressiveNPC(w *ecs.World, npcEntity ecs.Entity, npc
 	// If not in combat, look for targets
 	if combat == nil || combat.TargetID == "" {
 		npc.RLock()
-		room := npc.Room
+		area := npc.Area
 		npc.RUnlock()
 
-		if room != nil && len(room.Players) > 0 {
+		if area != nil && len(area.Players) > 0 {
 			// Pick a random player to attack
-			room.PlayersMutex.RLock()
-			if len(room.Players) > 0 {
-				target := room.Players[rand.Intn(len(room.Players))]
-				room.PlayersMutex.RUnlock()
+			area.PlayersMutex.RLock()
+			if len(area.Players) > 0 {
+				target := area.Players[rand.Intn(len(area.Players))]
+				area.PlayersMutex.RUnlock()
 
 				// Find player entity
 				playerEntities, _ := w.FindEntitiesByComponentPredicate("Player", func(i interface{}) bool {
@@ -98,10 +98,10 @@ func (as *AISystem) processAggressiveNPC(w *ecs.World, npcEntity ecs.Entity, npc
 					}
 					w.AddComponent(&npcEntity, newCombat)
 
-					room.Broadcast(npc.Name + " attacks " + target.Name + "!")
+					area.Broadcast(npc.Name + " attacks " + target.Name + "!")
 				}
 			} else {
-				room.PlayersMutex.RUnlock()
+				area.PlayersMutex.RUnlock()
 			}
 		}
 	}
@@ -111,8 +111,8 @@ func (as *AISystem) processFriendlyNPC(w *ecs.World, npcEntity ecs.Entity, npc *
 	// Occasionally say something
 	if time.Since(npc.LastAction) > 30*time.Second && rand.Float64() < 0.3 {
 		dialogue := npc.GetRandomDialogue()
-		if dialogue != "" && npc.Room != nil {
-			npc.Room.Broadcast(npc.Name + " says: " + dialogue)
+		if dialogue != "" && npc.Area != nil {
+			npc.Area.Broadcast(npc.Name + " says: " + dialogue)
 			npc.Lock()
 			defer npc.Unlock()
 			npc.LastAction = time.Now()
@@ -130,8 +130,8 @@ func (as *AISystem) processPassiveNPC(w *ecs.World, npcEntity ecs.Entity, npc *c
 	// Passive NPCs might flee when attacked or just emote
 	if time.Since(npc.LastAction) > 45*time.Second && rand.Float64() < 0.2 {
 		dialogue := npc.GetRandomDialogue()
-		if dialogue != "" && npc.Room != nil {
-			npc.Room.Broadcast(npc.Name + " " + dialogue)
+		if dialogue != "" && npc.Area != nil {
+			npc.Area.Broadcast(npc.Name + " " + dialogue)
 			npc.Lock()
 			defer npc.Unlock()
 			npc.LastAction = time.Now()

--- a/internal/systems/combat.go
+++ b/internal/systems/combat.go
@@ -33,16 +33,16 @@ func (cs *CombatSystem) Update(w *ecs.World, deltaTime float64) {
 
 		// Get attacker info (could be player or NPC)
 		var attackerName string
-		var attackerRoom *components.Room
+		var attackerArea *components.Area
 		attackerPlayer, _ := getPlayerComponent(w, attackingEntity.ID)
 		attackerNPC, _ := getNPCComponent(w, attackingEntity.ID)
 
 		if attackerPlayer != nil {
 			attackerName = attackerPlayer.Name
-			attackerRoom = attackerPlayer.Room
+			attackerArea = attackerPlayer.Area
 		} else if attackerNPC != nil {
 			attackerName = attackerNPC.Name
-			attackerRoom = attackerNPC.Room
+			attackerArea = attackerNPC.Area
 		} else {
 			// Neither player nor NPC
 			w.RemoveComponent(attackingEntity.ID, "Combat")
@@ -52,16 +52,16 @@ func (cs *CombatSystem) Update(w *ecs.World, deltaTime float64) {
 		// Get target info (could be player or NPC)
 		targetID := common.EntityID(combat.TargetID)
 		var targetName string
-		var targetRoom *components.Room
+		var targetArea *components.Area
 		targetPlayer, _ := getPlayerComponent(w, targetID)
 		targetNPC, _ := getNPCComponent(w, targetID)
 
 		if targetPlayer != nil {
 			targetName = targetPlayer.Name
-			targetRoom = targetPlayer.Room
+			targetArea = targetPlayer.Area
 		} else if targetNPC != nil {
 			targetName = targetNPC.Name
-			targetRoom = targetNPC.Room
+			targetArea = targetNPC.Area
 		} else {
 			// Target no longer exists
 			combat.TargetID = ""
@@ -71,8 +71,8 @@ func (cs *CombatSystem) Update(w *ecs.World, deltaTime float64) {
 			continue
 		}
 
-		// Verify both are in same room
-		if attackerRoom != targetRoom {
+		// Verify both are in same area
+		if attackerArea != targetArea {
 			combat.TargetID = ""
 			if attackerPlayer != nil {
 				attackerPlayer.Broadcast("Your target is no longer here.")
@@ -146,9 +146,9 @@ func handleTargetDeath(w components.WorldLike, attackerID common.EntityID, targe
 		targetPlayer.Broadcast("You have died!")
 		if attackerPlayer != nil {
 			attackerPlayer.Broadcast(fmt.Sprintf("You killed %s!", targetPlayer.Name))
-			targetPlayer.Room.Broadcast(fmt.Sprintf("%s has been slain by %s!", targetPlayer.Name, attackerPlayer.Name))
+			targetPlayer.Area.Broadcast(fmt.Sprintf("%s has been slain by %s!", targetPlayer.Name, attackerPlayer.Name))
 		} else if attackerNPC != nil {
-			targetPlayer.Room.Broadcast(fmt.Sprintf("%s has been slain by %s!", targetPlayer.Name, attackerNPC.Name))
+			targetPlayer.Area.Broadcast(fmt.Sprintf("%s has been slain by %s!", targetPlayer.Name, attackerNPC.Name))
 		}
 
 		// TODO: Handle respawn
@@ -161,8 +161,8 @@ func handleTargetDeath(w components.WorldLike, attackerID common.EntityID, targe
 		}
 	} else if targetNPC != nil {
 		// NPC died
-		if targetNPC.Room != nil {
-			targetNPC.Room.Broadcast(targetNPC.Name + " has been slain!")
+		if targetNPC.Area != nil {
+			targetNPC.Area.Broadcast(targetNPC.Name + " has been slain!")
 		}
 
 		if attackerPlayer != nil {

--- a/internal/systems/movement.go
+++ b/internal/systems/movement.go
@@ -54,22 +54,22 @@ func HandleMovement(w *ecs.World, movingEntity ecs.Entity) {
 		return
 	}
 
-	room := movingPlayer.Room
-	if room == nil {
-		log.Warn().Msgf("%v moving, but not in a room", movingPlayer)
+	area := movingPlayer.Area
+	if area == nil {
+		log.Warn().Msgf("%v moving, but not in an area", movingPlayer)
 		movingPlayer.Broadcast("Do you know where you are?")
 		return
 	}
 
-	exit := room.GetExit(moving.Direction)
+	exit := area.GetExit(moving.Direction)
 	if exit == nil {
 		movingPlayer.Broadcast("You can't go that way.")
 		return
 	}
 
-	room.RemovePlayer(movingPlayer)
+	area.RemovePlayer(movingPlayer)
 
-	movingPlayer.Room = exit.Room
-	movingPlayer.Room.AddPlayer(movingPlayer)
-	movingPlayer.Broadcast(exit.Room.Description)
+	movingPlayer.Area = exit.Area
+	movingPlayer.Area.AddPlayer(movingPlayer)
+	movingPlayer.Broadcast(exit.Area.Description)
 }

--- a/resources/areas.json
+++ b/resources/areas.json
@@ -1,6 +1,7 @@
 [
     {
         "id": "1",
+        "region": "Whispering Woods",
         "exits": {
             "north": "2",
             "east": "7"
@@ -9,6 +10,7 @@
     },
     {
         "id": "2",
+        "region": "Whispering Woods",
         "exits": {
             "north": "3",
             "south": "1",
@@ -18,6 +20,7 @@
     },
     {
         "id": "3",
+        "region": "Whispering Woods",
         "exits": {
             "south": "2",
             "east": "5",
@@ -27,6 +30,7 @@
     },
     {
         "id": "4",
+        "region": "Whispering Woods",
         "exits": {
             "west": "2",
             "north": "5"
@@ -35,6 +39,7 @@
     },
     {
         "id": "5",
+        "region": "Whispering Woods",
         "exits": {
             "west": "3",
             "south": "4"
@@ -43,6 +48,7 @@
     },
     {
         "id": "6",
+        "region": "Whispering Woods",
         "exits": {
             "east": "3"
         },
@@ -50,6 +56,7 @@
     },
     {
         "id": "7",
+        "region": "Forsaken Keep",
         "exits": {
             "west": "1",
             "east": "8",
@@ -59,6 +66,7 @@
     },
     {
         "id": "8",
+        "region": "Forsaken Keep",
         "exits": {
             "west": "7",
             "north": "9",
@@ -68,6 +76,7 @@
     },
     {
         "id": "9",
+        "region": "Forsaken Keep",
         "exits": {
             "south": "8",
             "east": "15"
@@ -76,6 +85,7 @@
     },
     {
         "id": "10",
+        "region": "Forsaken Keep",
         "exits": {
             "west": "8",
             "down": "12"
@@ -84,6 +94,7 @@
     },
     {
         "id": "11",
+        "region": "Forsaken Keep",
         "exits": {
             "north": "7",
             "down": "13"
@@ -92,6 +103,7 @@
     },
     {
         "id": "12",
+        "region": "Undercrypt Depths",
         "exits": {
             "up": "10",
             "north": "14"
@@ -100,6 +112,7 @@
     },
     {
         "id": "13",
+        "region": "Undercrypt Depths",
         "exits": {
             "up": "11",
             "east": "14"
@@ -108,6 +121,7 @@
     },
     {
         "id": "14",
+        "region": "Undercrypt Depths",
         "exits": {
             "west": "13",
             "south": "12",
@@ -117,6 +131,7 @@
     },
     {
         "id": "15",
+        "region": "Undercrypt Depths",
         "exits": {
             "west": "14",
             "up": "9"


### PR DESCRIPTION
## Summary
- replace the Room component with a new Area type that tracks exits, occupants, and an optional region
- update world loading and game initialization to read region-aware area data from resources/areas.json
- revise movement, combat, chat, spawn logic, and command help to operate on areas instead of rooms

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68d23139079c8320afba1146945dbafc