### PR TITLE
Refactor look output and use on join

### DIFF
--- a/internal/game/game.go
+++ b/internal/game/game.go
@@ -315,7 +315,7 @@ func (g *Game) HandleConnect(c common.Client) {
 	g.defaultArea.AddPlayer(playerComponent)
 
 	playerComponent.Broadcast(util.WelcomeBanner)
-	playerComponent.Broadcast(g.defaultArea.Description)
+	playerComponent.Look(g.world.AsWorldLike())
 
 	// if g.defaultArea.Region != "" {
 	// 	playerComponent.Broadcast("Region: " + g.defaultArea.Region)


### PR DESCRIPTION
## Summary
- add a reusable `Player.DescribeArea` helper that builds the look output
- have the look command and connection flow share the helper so players see the same details when joining

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d262c32f148320b9ccb85cbfdf6736