### PR TITLE
Integrate wandering into AI system

### DIFF
--- a/internal/components/npc.go
+++ b/internal/components/npc.go
@@ -11,14 +11,15 @@ import (
 type NPC struct {
 	sync.RWMutex
 
-	Name        string
-	Description string
-	Area        *Area
-	TemplateID  string
-	Behavior    NPCBehavior
-	Dialogue    []string
-	LastAction  time.Time
-	Target      common.EntityID // For aggressive NPCs
+	Name         string
+	Description  string
+	Area         *Area
+	TemplateID   string
+	Behavior     NPCBehavior
+	Dialogue     []string
+	LastAction   time.Time
+	LastMovement time.Time
+	Target       common.EntityID // For aggressive NPCs
 }
 
 func (n *NPC) GetRandomDialogue() string {

--- a/internal/systems/ai.go
+++ b/internal/systems/ai.go
@@ -8,6 +8,8 @@ import (
 	"time"
 )
 
+const wanderMinimumInterval = 20 * time.Second
+
 type AISystem struct {
 	lastUpdate time.Time
 }
@@ -54,10 +56,14 @@ func (as *AISystem) processNPCBehavior(w *ecs.World, npcEntity ecs.Entity) {
 		return
 	}
 
+	combat, _ := ecs.GetTypedComponent[*components.Combat](w, npcEntity.ID, "Combat")
+
+	as.attemptWander(w, npcEntity, npc, combat)
+
 	// Process based on behavior type
 	switch npc.Behavior {
 	case components.BehaviorAggressive:
-		as.processAggressiveNPC(w, npcEntity, npc)
+		as.processAggressiveNPC(w, npcEntity, npc, combat)
 	case components.BehaviorFriendly, components.BehaviorMerchant:
 		as.processFriendlyNPC(w, npcEntity, npc)
 	case components.BehaviorGuard:
@@ -67,11 +73,19 @@ func (as *AISystem) processNPCBehavior(w *ecs.World, npcEntity ecs.Entity) {
 	}
 }
 
-func (as *AISystem) processAggressiveNPC(w *ecs.World, npcEntity ecs.Entity, npc *components.NPC) {
-	combat, _ := ecs.GetTypedComponent[*components.Combat](w, npcEntity.ID, "Combat")
+func (as *AISystem) processAggressiveNPC(w *ecs.World, npcEntity ecs.Entity, npc *components.NPC, combat *components.Combat) {
+	if combat == nil {
+		return
+	}
+
+	combat.RLock()
+	hasTarget := combat.TargetID != ""
+	minDamage := combat.MinDamage
+	maxDamage := combat.MaxDamage
+	combat.RUnlock()
 
 	// If not in combat, look for targets
-	if combat == nil || combat.TargetID == "" {
+	if !hasTarget {
 		npc.RLock()
 		area := npc.Area
 		npc.RUnlock()
@@ -93,8 +107,8 @@ func (as *AISystem) processAggressiveNPC(w *ecs.World, npcEntity ecs.Entity, npc
 					// Start combat
 					newCombat := &components.Combat{
 						TargetID:  playerEntities[0].ID,
-						MinDamage: combat.MinDamage,
-						MaxDamage: combat.MaxDamage,
+						MinDamage: minDamage,
+						MaxDamage: maxDamage,
 					}
 					w.AddComponent(&npcEntity, newCombat)
 
@@ -105,6 +119,78 @@ func (as *AISystem) processAggressiveNPC(w *ecs.World, npcEntity ecs.Entity, npc
 			}
 		}
 	}
+}
+
+func (as *AISystem) attemptWander(w *ecs.World, npcEntity ecs.Entity, npc *components.NPC, combat *components.Combat) {
+	if combat != nil {
+		combat.RLock()
+		inCombat := combat.TargetID != ""
+		combat.RUnlock()
+		if inCombat {
+			return
+		}
+	}
+
+	npc.RLock()
+	currentArea := npc.Area
+	lastMovement := npc.LastMovement
+	name := npc.Name
+	npc.RUnlock()
+
+	if currentArea == nil {
+		return
+	}
+
+	if time.Since(lastMovement) < wanderMinimumInterval {
+		return
+	}
+
+	if rand.Float64() > 0.5 {
+		return
+	}
+
+	exits := regionExits(currentArea)
+	if len(exits) == 0 {
+		return
+	}
+
+	chosenExit := exits[rand.Intn(len(exits))]
+	destination := chosenExit.Area
+	if destination == nil || destination == currentArea {
+		return
+	}
+
+	currentArea.Broadcast(name + " wanders " + chosenExit.Direction + ".")
+
+	npc.Lock()
+	if npc.Area != currentArea {
+		npc.Unlock()
+		return
+	}
+	npc.Area = destination
+	npc.LastMovement = time.Now()
+	npc.Unlock()
+
+	destination.Broadcast(name + " wanders in.")
+}
+
+func regionExits(area *components.Area) []components.Exit {
+	if area == nil {
+		return nil
+	}
+
+	region := area.Region
+	exits := make([]components.Exit, 0, len(area.Exits))
+	for _, exit := range area.Exits {
+		if exit.Area == nil {
+			continue
+		}
+		if exit.Area.Region != region {
+			continue
+		}
+		exits = append(exits, exit)
+	}
+	return exits
 }
 
 func (as *AISystem) processFriendlyNPC(w *ecs.World, npcEntity ecs.Entity, npc *components.NPC) {

--- a/internal/systems/spawn.go
+++ b/internal/systems/spawn.go
@@ -129,13 +129,14 @@ func (ss *SpawnSystem) spawnNPC(w *ecs.World, area *components.Area, config comp
 
 	// Add NPC component
 	npc := &components.NPC{
-		Name:        template.Name,
-		Description: template.Description,
-		Area:        area,
-		TemplateID:  template.ID,
-		Behavior:    template.Behavior,
-		Dialogue:    template.Dialogue,
-		LastAction:  time.Now(),
+		Name:         template.Name,
+		Description:  template.Description,
+		Area:         area,
+		TemplateID:   template.ID,
+		Behavior:     template.Behavior,
+		Dialogue:     template.Dialogue,
+		LastAction:   time.Now(),
+		LastMovement: time.Now(),
 	}
 	w.AddComponent(&npcEntity, npc)
 


### PR DESCRIPTION
## Summary
- fold the region-aware wander behavior into the AISystem so NPC roaming lives alongside other decision making
- skip registering a dedicated wander system now that movement is handled inside AI processing
- retain combat-aware wander checks and region exit filtering when NPCs decide to move

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d39f28c458832081aaeff71235ba33