### PR TITLE
Make guards intervene against aggressors

### DIFF
--- a/internal/systems/spawn.go
+++ b/internal/systems/spawn.go
@@ -148,8 +148,8 @@ func (ss *SpawnSystem) spawnNPC(w *ecs.World, area *components.Area, config comp
 	}
 	w.AddComponent(&npcEntity, health)
 
-	// Add Combat component for aggressive NPCs
-	if template.Behavior == components.BehaviorAggressive {
+	// Add Combat component for NPCs that can fight on their own
+	if template.Behavior == components.BehaviorAggressive || template.Behavior == components.BehaviorGuard {
 		combat := &components.Combat{
 			MinDamage: template.MinDamage,
 			MaxDamage: template.MaxDamage,


### PR DESCRIPTION
## Summary
- teach guard AI to scan their area for aggressors and attack those threatening citizens
- ensure guards pick targets across both NPC and player attackers while retaining their friendly idle behaviour
- spawn guards with combat capability so they can join fights when necessary

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d3b79de86083208b53fd0cb4ea6d9e