### PR TITLE
Add control undead and charm spells

### DIFF
--- a/internal/components/npc_template.go
+++ b/internal/components/npc_template.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"math/rand"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/rs/zerolog/log"
@@ -36,18 +37,49 @@ type LootDrop struct {
 	MaxCount int
 }
 
+type CreatureType int
+
+const (
+	CreatureTypeUnknown CreatureType = iota
+	CreatureTypeHumanoid
+	CreatureTypeBeast
+	CreatureTypeUndead
+)
+
+var creatureTypeFromString = map[string]CreatureType{
+	"":         CreatureTypeHumanoid,
+	"unknown":  CreatureTypeUnknown,
+	"humanoid": CreatureTypeHumanoid,
+	"beast":    CreatureTypeBeast,
+	"undead":   CreatureTypeUndead,
+}
+
+func (c CreatureType) String() string {
+	switch c {
+	case CreatureTypeHumanoid:
+		return "humanoid"
+	case CreatureTypeBeast:
+		return "beast"
+	case CreatureTypeUndead:
+		return "undead"
+	default:
+		return "unknown"
+	}
+}
+
 type NPCTemplate struct {
-	ID          string
-	Name        string
-	Description string
-	Health      int
-	MinDamage   int
-	MaxDamage   int
-	Behavior    NPCBehavior
-	Dialogue    []string // Random things they might say
-	RespawnTime time.Duration
-	Stationary  bool       // If true, NPC will not wander between areas
-	LootTable   []LootDrop // Possible items this NPC can drop
+	ID           string
+	Name         string
+	Description  string
+	Health       int
+	MinDamage    int
+	MaxDamage    int
+	CreatureType CreatureType
+	Behavior     NPCBehavior
+	Dialogue     []string // Random things they might say
+	RespawnTime  time.Duration
+	Stationary   bool       // If true, NPC will not wander between areas
+	LootTable    []LootDrop // Possible items this NPC can drop
 }
 
 // JSON structs for loading
@@ -65,6 +97,7 @@ type npcTemplateJSON struct {
 	Health             int            `json:"health"`
 	MinDamage          int            `json:"min_damage"`
 	MaxDamage          int            `json:"max_damage"`
+	CreatureType       string         `json:"creature_type,omitempty"`
 	Behavior           string         `json:"behavior"`
 	Dialogue           []string       `json:"dialogue"`
 	RespawnTimeSeconds int            `json:"respawn_time_seconds"`
@@ -102,18 +135,25 @@ func LoadNPCTemplates(filename string) error {
 			behavior = BehaviorPassive
 		}
 
+		creatureType, ok := creatureTypeFromString[strings.ToLower(strings.TrimSpace(t.CreatureType))]
+		if !ok {
+			log.Warn().Msgf("Unknown creature_type '%s' for NPC '%s', defaulting to humanoid", t.CreatureType, t.ID)
+			creatureType = CreatureTypeHumanoid
+		}
+
 		NPCTemplates[t.ID] = NPCTemplate{
-			ID:          t.ID,
-			Name:        t.Name,
-			Description: t.Description,
-			Health:      t.Health,
-			MinDamage:   t.MinDamage,
-			MaxDamage:   t.MaxDamage,
-			Behavior:    behavior,
-			Dialogue:    t.Dialogue,
-			RespawnTime: time.Duration(t.RespawnTimeSeconds) * time.Second,
-			Stationary:  t.Stationary,
-			LootTable:   lootTable,
+			ID:           t.ID,
+			Name:         t.Name,
+			Description:  t.Description,
+			Health:       t.Health,
+			MinDamage:    t.MinDamage,
+			MaxDamage:    t.MaxDamage,
+			CreatureType: creatureType,
+			Behavior:     behavior,
+			Dialogue:     t.Dialogue,
+			RespawnTime:  time.Duration(t.RespawnTimeSeconds) * time.Second,
+			Stationary:   t.Stationary,
+			LootTable:    lootTable,
 		}
 	}
 

--- a/internal/components/status_effect.go
+++ b/internal/components/status_effect.go
@@ -1,6 +1,7 @@
 package components
 
 import (
+	"dmud/internal/common"
 	"sync"
 	"time"
 )
@@ -9,6 +10,8 @@ type StatusEffectType int
 
 const (
 	StatusEffectGuardBlessing StatusEffectType = iota
+	StatusEffectControlledUndead
+	StatusEffectCharmed
 )
 
 type StatusEffect struct {
@@ -18,6 +21,10 @@ type StatusEffect struct {
 	Duration  time.Duration
 	HPBonus   int
 	Applied   bool
+
+	SourceEntityID      common.EntityID
+	SuppressAggro       bool
+	SuppressRetaliation bool
 }
 
 type StatusEffects struct {
@@ -57,16 +64,16 @@ func (se *StatusEffects) HasEffect(effectType StatusEffectType) bool {
 	return false
 }
 
-func (se *StatusEffects) GetEffect(effectType StatusEffectType) (*StatusEffect, bool) {
+func (se *StatusEffects) GetEffect(effectType StatusEffectType) (StatusEffect, bool) {
 	se.RLock()
 	defer se.RUnlock()
 
 	for i := range se.Effects {
 		if se.Effects[i].Type == effectType && !se.isExpired(se.Effects[i]) {
-			return &se.Effects[i], true
+			return se.Effects[i], true
 		}
 	}
-	return nil, false
+	return StatusEffect{}, false
 }
 
 func (se *StatusEffects) RemoveExpired() []StatusEffect {
@@ -106,4 +113,46 @@ func (se *StatusEffects) GetTotalHPBonus() int {
 		}
 	}
 	return total
+}
+
+func (se *StatusEffects) HasSuppressedAggro() bool {
+	se.RLock()
+	defer se.RUnlock()
+
+	for _, effect := range se.Effects {
+		if !se.isExpired(effect) && effect.SuppressAggro {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (se *StatusEffects) HasSuppressedRetaliation() bool {
+	se.RLock()
+	defer se.RUnlock()
+
+	for _, effect := range se.Effects {
+		if !se.isExpired(effect) && effect.SuppressRetaliation {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (se *StatusEffects) GetActiveSuppressionEffect() (StatusEffect, bool) {
+	se.RLock()
+	defer se.RUnlock()
+
+	for _, effect := range se.Effects {
+		if se.isExpired(effect) {
+			continue
+		}
+		if effect.SuppressAggro || effect.SuppressRetaliation {
+			return effect, true
+		}
+	}
+
+	return StatusEffect{}, false
 }

--- a/internal/game/commands.go
+++ b/internal/game/commands.go
@@ -38,7 +38,7 @@ var commandHelpText = map[string]string{
 	"sacall":    "Destroy all items on the ground (optionally matching a pattern). Usage: sacall [pattern]",
 	"login":     "Associate this session with a UUID. Usage: login <uuid>",
 	"save":      "Save your character and receive a UUID for login. Usage: save",
-	"cast":      "Cast a spell. Usage: cast heal [target]",
+	"cast":      "Cast a spell. Usage: cast <spell> [target] (known: heal, charm, control undead)",
 	"summon":    "Summon a player to your location. Admins can always summon. Usage: summon <player>",
 	"hail":      "Hail an NPC to start a conversation. Usage: hail <npc_name>",
 	"uptime":    "Show server uptime, current players, and connection statistics.",
@@ -159,7 +159,7 @@ func handleHelp(player *components.Player, args []string, game *Game) {
 		b.WriteString("  login <uuid>      - Link this session to a UUID\n")
 		b.WriteString("  save              - Save your character and get a UUID\n")
 		b.WriteString("  recall            - Return to starting area\n\n")
-		b.WriteString("  cast <spell> [target] - Cast a spell (heal)\n\n")
+		b.WriteString("  cast <spell> [target] - Cast a spell (heal, charm, control undead)\n\n")
 
 		b.WriteString("UTILITY\n")
 		b.WriteString("  help [command]    - Show help information\n")

--- a/internal/game/misc.go
+++ b/internal/game/misc.go
@@ -90,16 +90,18 @@ func handleSave(player *components.Player, args []string, game *Game) {
 func handleCast(player *components.Player, args []string, game *Game) {
 	if len(args) == 0 {
 		player.Broadcast("Usage: cast <spell> [target]")
+		player.Broadcast("Known spells: " + strings.Join(listKnownSpells(), ", "))
 		return
 	}
 
-	spell := strings.ToLower(strings.TrimSpace(args[0]))
-	switch spell {
-	case "heal", "healing":
-		castHeal(player, args[1:], game)
-	default:
+	spell, consumed := resolveSpellFromArgs(args)
+	if spell == nil {
 		player.Broadcast("You don't know that spell.")
+		player.Broadcast("Known spells: " + strings.Join(listKnownSpells(), ", "))
+		return
 	}
+
+	spell.Handler(player, args[consumed:], game)
 }
 
 func castHeal(caster *components.Player, args []string, game *Game) {

--- a/internal/game/persistence.go
+++ b/internal/game/persistence.go
@@ -195,12 +195,15 @@ func (g *Game) buildPlayerState(entityID common.EntityID, player *components.Pla
 			state.StatusEffects = make([]persistence.StatusEffectState, 0, len(effects.Effects))
 			for _, effect := range effects.Effects {
 				state.StatusEffects = append(state.StatusEffects, persistence.StatusEffectState{
-					Type:           effect.Type,
-					Name:           effect.Name,
-					AppliedAtUnix:  effect.AppliedAt.Unix(),
-					DurationSecond: int64(effect.Duration.Seconds()),
-					HPBonus:        effect.HPBonus,
-					Applied:        effect.Applied,
+					Type:                effect.Type,
+					Name:                effect.Name,
+					AppliedAtUnix:       effect.AppliedAt.Unix(),
+					DurationSecond:      int64(effect.Duration.Seconds()),
+					HPBonus:             effect.HPBonus,
+					Applied:             effect.Applied,
+					SourceEntityID:      string(effect.SourceEntityID),
+					SuppressAggro:       effect.SuppressAggro,
+					SuppressRetaliation: effect.SuppressRetaliation,
 				})
 			}
 			effects.RUnlock()
@@ -277,12 +280,15 @@ func (g *Game) applyPlayerState(entityID common.EntityID, player *components.Pla
 				continue
 			}
 			effects.Effects = append(effects.Effects, components.StatusEffect{
-				Type:      saved.Type,
-				Name:      saved.Name,
-				AppliedAt: appliedAt,
-				Duration:  duration,
-				HPBonus:   saved.HPBonus,
-				Applied:   saved.Applied,
+				Type:                saved.Type,
+				Name:                saved.Name,
+				AppliedAt:           appliedAt,
+				Duration:            duration,
+				HPBonus:             saved.HPBonus,
+				Applied:             saved.Applied,
+				SourceEntityID:      common.EntityID(saved.SourceEntityID),
+				SuppressAggro:       saved.SuppressAggro,
+				SuppressRetaliation: saved.SuppressRetaliation,
 			})
 		}
 		if len(effects.Effects) > 0 {

--- a/internal/game/spells.go
+++ b/internal/game/spells.go
@@ -1,0 +1,445 @@
+package game
+
+import (
+	"dmud/internal/common"
+	"dmud/internal/components"
+	"dmud/internal/ecs"
+	"fmt"
+	"math/rand"
+	"sort"
+	"strings"
+	"time"
+)
+
+type SpellHandler func(caster *components.Player, args []string, game *Game)
+
+type SpellDefinition struct {
+	Name        string
+	Aliases     []string
+	Usage       string
+	Description string
+	Handler     SpellHandler
+}
+
+type npcControlSpellSpec struct {
+	Usage                string
+	EffectType           components.StatusEffectType
+	EffectName           string
+	DurationForLevel     func(level int) time.Duration
+	CanTarget            func(template components.NPCTemplate) bool
+	InvalidTargetMessage func(npcName string) string
+	ConflictMessage      func(npcName string) string
+	SuccessModifier      int
+	ResistCasterMessage  func(npcName string) string
+	ResistAreaMessage    func(casterName, npcName string) string
+	CasterMessage        func(npcName string, duration time.Duration, renewed bool) string
+	AreaMessage          func(casterName, npcName string, renewed bool) string
+}
+
+var spellRegistry = make(map[string]*SpellDefinition)
+var maxSpellWords = 1
+
+func init() {
+	registerSpell(&SpellDefinition{
+		Name:        "heal",
+		Aliases:     []string{"healing"},
+		Usage:       "cast heal [target]",
+		Description: "Restore health to yourself or another player.",
+		Handler:     castHeal,
+	})
+	registerSpell(&SpellDefinition{
+		Name:        "control undead",
+		Aliases:     []string{"controlundead", "command undead"},
+		Usage:       "cast control undead <target>",
+		Description: "Suppress an undead creature's aggression for a short time.",
+		Handler:     castControlUndead,
+	})
+	registerSpell(&SpellDefinition{
+		Name:        "charm",
+		Aliases:     []string{"charm person"},
+		Usage:       "cast charm <target>",
+		Description: "Beguile a living creature and suppress its aggression temporarily.",
+		Handler:     castCharm,
+	})
+}
+
+func registerSpell(def *SpellDefinition) {
+	if def == nil {
+		return
+	}
+
+	keys := make([]string, 0, len(def.Aliases)+1)
+	keys = append(keys, def.Name)
+	keys = append(keys, def.Aliases...)
+
+	for _, key := range keys {
+		normalized := normalizeSpellKey(key)
+		if normalized == "" {
+			continue
+		}
+		spellRegistry[normalized] = def
+
+		if words := len(strings.Fields(normalized)); words > maxSpellWords {
+			maxSpellWords = words
+		}
+	}
+}
+
+func normalizeSpellKey(raw string) string {
+	normalized := strings.ToLower(strings.TrimSpace(raw))
+	if normalized == "" {
+		return ""
+	}
+	return strings.Join(strings.Fields(normalized), " ")
+}
+
+func resolveSpellFromArgs(args []string) (*SpellDefinition, int) {
+	if len(args) == 0 {
+		return nil, 0
+	}
+
+	maxWords := maxSpellWords
+	if len(args) < maxWords {
+		maxWords = len(args)
+	}
+
+	for words := maxWords; words >= 1; words-- {
+		candidate := normalizeSpellKey(strings.Join(args[:words], " "))
+		if spell, ok := spellRegistry[candidate]; ok {
+			return spell, words
+		}
+	}
+
+	return nil, 1
+}
+
+func listKnownSpells() []string {
+	unique := make(map[string]struct{})
+	for _, spell := range spellRegistry {
+		unique[spell.Name] = struct{}{}
+	}
+
+	names := make([]string, 0, len(unique))
+	for name := range unique {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func castControlUndead(caster *components.Player, args []string, game *Game) {
+	castNPCControlSpell(caster, args, game, npcControlSpellSpec{
+		Usage:            "Usage: cast control undead <target>",
+		EffectType:       components.StatusEffectControlledUndead,
+		EffectName:       "Controlled Undead",
+		DurationForLevel: controlUndeadDuration,
+		CanTarget: func(template components.NPCTemplate) bool {
+			return template.CreatureType == components.CreatureTypeUndead
+		},
+		InvalidTargetMessage: func(npcName string) string {
+			return fmt.Sprintf("%s is not undead.", npcName)
+		},
+		ConflictMessage: func(npcName string) string {
+			return fmt.Sprintf("%s is already controlled by another will.", npcName)
+		},
+		SuccessModifier: 10,
+		ResistCasterMessage: func(npcName string) string {
+			return fmt.Sprintf("%s resists your necromantic command.", npcName)
+		},
+		ResistAreaMessage: func(casterName, npcName string) string {
+			return fmt.Sprintf("%s's command falters as %s resists.", casterName, npcName)
+		},
+		CasterMessage: func(npcName string, duration time.Duration, renewed bool) string {
+			if renewed {
+				return fmt.Sprintf("You renew your control over %s for %s.", npcName, shortDuration(duration))
+			}
+			return fmt.Sprintf("You seize control of %s for %s.", npcName, shortDuration(duration))
+		},
+		AreaMessage: func(casterName, npcName string, renewed bool) string {
+			if renewed {
+				return fmt.Sprintf("%s reasserts a necromantic command over %s.", casterName, npcName)
+			}
+			return fmt.Sprintf("%s utters a necromantic command and %s falls still.", casterName, npcName)
+		},
+	})
+}
+
+func castCharm(caster *components.Player, args []string, game *Game) {
+	castNPCControlSpell(caster, args, game, npcControlSpellSpec{
+		Usage:            "Usage: cast charm <target>",
+		EffectType:       components.StatusEffectCharmed,
+		EffectName:       "Charmed",
+		DurationForLevel: charmDuration,
+		CanTarget: func(template components.NPCTemplate) bool {
+			return template.CreatureType != components.CreatureTypeUndead
+		},
+		InvalidTargetMessage: func(npcName string) string {
+			return fmt.Sprintf("%s cannot be charmed by living magic.", npcName)
+		},
+		ConflictMessage: func(npcName string) string {
+			return fmt.Sprintf("%s is already enthralled by another will.", npcName)
+		},
+		ResistCasterMessage: func(npcName string) string {
+			return fmt.Sprintf("%s shrugs off your charm.", npcName)
+		},
+		ResistAreaMessage: func(casterName, npcName string) string {
+			return fmt.Sprintf("%s's charm fizzles as %s resists.", casterName, npcName)
+		},
+		CasterMessage: func(npcName string, duration time.Duration, renewed bool) string {
+			if renewed {
+				return fmt.Sprintf("You deepen your charm over %s for %s.", npcName, shortDuration(duration))
+			}
+			return fmt.Sprintf("You charm %s for %s.", npcName, shortDuration(duration))
+		},
+		AreaMessage: func(casterName, npcName string, renewed bool) string {
+			if renewed {
+				return fmt.Sprintf("%s renews a beguiling charm over %s.", casterName, npcName)
+			}
+			return fmt.Sprintf("%s weaves beguiling magic around %s.", casterName, npcName)
+		},
+	})
+}
+
+func castNPCControlSpell(caster *components.Player, args []string, game *Game, spec npcControlSpellSpec) {
+	if len(args) == 0 {
+		usage := strings.TrimSpace(spec.Usage)
+		if usage == "" {
+			usage = "Usage: cast <spell> <target>"
+		}
+		caster.Broadcast(usage)
+		return
+	}
+	if caster.Area == nil {
+		caster.Broadcast("You are nowhere.")
+		return
+	}
+
+	targetName := strings.TrimSpace(strings.Join(args, " "))
+	npc, npcEntityID, err := game.findNPCInAreaByName(caster.Area, targetName)
+	if err != nil {
+		caster.Broadcast(fmt.Sprintf("Invalid target: %v", err))
+		return
+	}
+	if npc == nil {
+		caster.Broadcast("You don't see that here.")
+		return
+	}
+
+	npc.RLock()
+	npcName := npc.Name
+	npcTemplateID := npc.TemplateID
+	npc.RUnlock()
+
+	template, ok := components.NPCTemplates[npcTemplateID]
+	if !ok {
+		caster.Broadcast("The spell cannot find purchase on that target.")
+		return
+	}
+	if spec.CanTarget != nil && !spec.CanTarget(template) {
+		if spec.InvalidTargetMessage != nil {
+			caster.Broadcast(spec.InvalidTargetMessage(npcName))
+		} else {
+			caster.Broadcast(fmt.Sprintf("%s is not a valid target.", npcName))
+		}
+		return
+	}
+
+	casterEntityID, err := game.getPlayerEntity(caster)
+	if err != nil {
+		caster.Broadcast("You lose focus and the spell fizzles.")
+		return
+	}
+
+	level := 1
+	if expComp, err := game.world.GetComponent(casterEntityID, "Experience"); err == nil {
+		if exp, ok := expComp.(*components.Experience); ok {
+			level = exp.GetLevel()
+		}
+	}
+
+	duration := 45 * time.Second
+	if spec.DurationForLevel != nil {
+		duration = spec.DurationForLevel(level)
+	}
+
+	statusEffects, err := game.getOrCreateStatusEffects(npcEntityID)
+	if err != nil {
+		caster.Broadcast("The magic fails to take hold.")
+		return
+	}
+
+	if controlEffect, ok := statusEffects.GetActiveSuppressionEffect(); ok {
+		if controlEffect.SourceEntityID != "" && controlEffect.SourceEntityID != casterEntityID {
+			if spec.ConflictMessage != nil {
+				caster.Broadcast(spec.ConflictMessage(npcName))
+			} else {
+				caster.Broadcast(fmt.Sprintf("%s is already under another controlling effect.", npcName))
+			}
+			return
+		}
+	}
+
+	_, renewed := statusEffects.GetEffect(spec.EffectType)
+	if !renewed {
+		successChance := controlSpellSuccessChance(level, template, spec.SuccessModifier)
+		if !rollPercent(successChance) {
+			if spec.ResistCasterMessage != nil {
+				caster.Broadcast(spec.ResistCasterMessage(npcName))
+			} else {
+				caster.Broadcast(fmt.Sprintf("%s resists your spell.", npcName))
+			}
+			if spec.ResistAreaMessage != nil {
+				areaMessage := strings.TrimSpace(spec.ResistAreaMessage(caster.Name, npcName))
+				if areaMessage != "" {
+					caster.Area.Broadcast(areaMessage, caster)
+				}
+			}
+			return
+		}
+	}
+
+	statusEffects.AddEffect(components.StatusEffect{
+		Type:                spec.EffectType,
+		Name:                spec.EffectName,
+		AppliedAt:           time.Now(),
+		Duration:            duration,
+		Applied:             true,
+		SourceEntityID:      casterEntityID,
+		SuppressAggro:       true,
+		SuppressRetaliation: true,
+	})
+
+	if combat, err := ecs.GetTypedComponent[*components.Combat](game.world, npcEntityID, "Combat"); err == nil {
+		combat.Lock()
+		combat.TargetID = ""
+		combat.TargetQueue = nil
+		combat.Unlock()
+	}
+
+	if spec.CasterMessage != nil {
+		caster.Broadcast(spec.CasterMessage(npcName, duration, renewed))
+	} else {
+		caster.Broadcast(fmt.Sprintf("You control %s for %s.", npcName, shortDuration(duration)))
+	}
+
+	if spec.AreaMessage != nil {
+		areaMessage := strings.TrimSpace(spec.AreaMessage(caster.Name, npcName, renewed))
+		if areaMessage != "" {
+			caster.Area.Broadcast(areaMessage, caster)
+		}
+	}
+}
+
+func controlUndeadDuration(level int) time.Duration {
+	if level < 1 {
+		level = 1
+	}
+
+	duration := 45*time.Second + (time.Duration(level) * 15 * time.Second)
+	if duration > 5*time.Minute {
+		return 5 * time.Minute
+	}
+	return duration
+}
+
+func charmDuration(level int) time.Duration {
+	if level < 1 {
+		level = 1
+	}
+
+	duration := 30*time.Second + (time.Duration(level) * 10 * time.Second)
+	if duration > 3*time.Minute {
+		return 3 * time.Minute
+	}
+	return duration
+}
+
+func controlSpellSuccessChance(level int, template components.NPCTemplate, successModifier int) int {
+	if level < 1 {
+		level = 1
+	}
+
+	targetPower := (template.Health / 20) + ((template.MinDamage + template.MaxDamage) / 6)
+	chance := 60 + (level * 5) - (targetPower * 5) + successModifier
+
+	if chance < 20 {
+		return 20
+	}
+	if chance > 90 {
+		return 90
+	}
+	return chance
+}
+
+func rollPercent(chance int) bool {
+	if chance <= 0 {
+		return false
+	}
+	if chance >= 100 {
+		return true
+	}
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	return rng.Intn(100) < chance
+}
+
+func shortDuration(duration time.Duration) string {
+	seconds := int(duration.Seconds())
+	if seconds < 60 {
+		return fmt.Sprintf("%ds", seconds)
+	}
+
+	minutes := seconds / 60
+	leftoverSeconds := seconds % 60
+	if leftoverSeconds == 0 {
+		return fmt.Sprintf("%dm", minutes)
+	}
+
+	return fmt.Sprintf("%dm%ds", minutes, leftoverSeconds)
+}
+
+func (g *Game) findNPCInAreaByName(area *components.Area, rawName string) (*components.NPC, common.EntityID, error) {
+	if area == nil {
+		return nil, "", nil
+	}
+
+	matcher, _, _, err := buildItemMatcher(rawName)
+	if err != nil {
+		return nil, "", err
+	}
+
+	npcs := area.GetNPCs(g.world.AsWorldLike())
+	for _, npc := range npcs {
+		if !matcher(npc.Name) {
+			continue
+		}
+
+		npcEntities, _ := g.world.FindEntitiesByComponentPredicate("NPC", func(i interface{}) bool {
+			n, ok := i.(*components.NPC)
+			return ok && n == npc
+		})
+		if len(npcEntities) == 0 {
+			continue
+		}
+
+		return npc, npcEntities[0].ID, nil
+	}
+
+	return nil, "", nil
+}
+
+func (g *Game) getOrCreateStatusEffects(entityID common.EntityID) (*components.StatusEffects, error) {
+	statusEffects, err := ecs.GetTypedComponent[*components.StatusEffects](g.world, entityID, "StatusEffects")
+	if err == nil && statusEffects != nil {
+		return statusEffects, nil
+	}
+
+	entity, err := g.world.FindEntity(entityID)
+	if err != nil {
+		return nil, err
+	}
+
+	statusEffects = components.NewStatusEffects()
+	g.world.AddComponent(&entity, statusEffects)
+	return statusEffects, nil
+}

--- a/internal/persistence/store.go
+++ b/internal/persistence/store.go
@@ -67,12 +67,15 @@ type QuestStatusRecord struct {
 }
 
 type StatusEffectState struct {
-	Type           components.StatusEffectType `json:"type"`
-	Name           string                      `json:"name"`
-	AppliedAtUnix  int64                       `json:"applied_at_unix"`
-	DurationSecond int64                       `json:"duration_seconds"`
-	HPBonus        int                         `json:"hp_bonus"`
-	Applied        bool                        `json:"applied"`
+	Type                components.StatusEffectType `json:"type"`
+	Name                string                      `json:"name"`
+	AppliedAtUnix       int64                       `json:"applied_at_unix"`
+	DurationSecond      int64                       `json:"duration_seconds"`
+	HPBonus             int                         `json:"hp_bonus"`
+	Applied             bool                        `json:"applied"`
+	SourceEntityID      string                      `json:"source_entity_id,omitempty"`
+	SuppressAggro       bool                        `json:"suppress_aggro,omitempty"`
+	SuppressRetaliation bool                        `json:"suppress_retaliation,omitempty"`
 }
 
 type WorldState struct {

--- a/internal/systems/ai.go
+++ b/internal/systems/ai.go
@@ -77,6 +77,14 @@ func (as *AISystem) processAggressiveNPC(w *ecs.World, npcEntity ecs.Entity, npc
 		return
 	}
 
+	if as.npcAggroSuppressed(w, npcEntity.ID) {
+		combat.Lock()
+		combat.TargetID = ""
+		combat.TargetQueue = nil
+		combat.Unlock()
+		return
+	}
+
 	combat.RLock()
 	hasTarget := combat.TargetID != ""
 	minDamage := combat.MinDamage
@@ -118,6 +126,14 @@ func (as *AISystem) processAggressiveNPC(w *ecs.World, npcEntity ecs.Entity, npc
 			}
 		}
 	}
+}
+
+func (as *AISystem) npcAggroSuppressed(w *ecs.World, npcID common.EntityID) bool {
+	statusEffects, err := ecs.GetTypedComponent[*components.StatusEffects](w, npcID, "StatusEffects")
+	if err != nil || statusEffects == nil {
+		return false
+	}
+	return statusEffects.HasSuppressedAggro()
 }
 
 func (as *AISystem) attemptWander(_ *ecs.World, _ ecs.Entity, npc *components.NPC, combat *components.Combat) {

--- a/internal/systems/combat.go
+++ b/internal/systems/combat.go
@@ -50,6 +50,14 @@ func (cs *CombatSystem) Update(w *ecs.World, deltaTime float64) {
 			continue
 		}
 
+		if attackerNPC != nil && hasSuppressedAggro(w, attackingEntity.ID) {
+			combat.Lock()
+			combat.TargetID = ""
+			combat.TargetQueue = nil
+			combat.Unlock()
+			continue
+		}
+
 		// Get target info (could be player or NPC)
 		targetID := common.EntityID(combat.TargetID)
 		var targetName string
@@ -109,6 +117,15 @@ func (cs *CombatSystem) Update(w *ecs.World, deltaTime float64) {
 
 		// Auto-retaliation: if target isn't already fighting back, make them attack the attacker
 		targetCombat, err := getCombatComponent(w, targetID)
+		if targetNPC != nil && hasSuppressedRetaliation(w, targetID) {
+			if err == nil {
+				targetCombat.Lock()
+				targetCombat.TargetID = ""
+				targetCombat.TargetQueue = nil
+				targetCombat.Unlock()
+			}
+			continue
+		}
 		if err != nil || targetCombat.TargetID == "" {
 			// Target doesn't have combat component or isn't attacking anyone
 			// Create or update combat component to attack back
@@ -170,6 +187,22 @@ func getNPCComponent(w *ecs.World, entityID common.EntityID) (*components.NPC, e
 
 func getHealthComponent(w *ecs.World, entityID common.EntityID) (*components.Health, error) {
 	return ecs.GetTypedComponent[*components.Health](w, entityID, "Health")
+}
+
+func hasSuppressedAggro(w *ecs.World, entityID common.EntityID) bool {
+	statusEffects, err := ecs.GetTypedComponent[*components.StatusEffects](w, entityID, "StatusEffects")
+	if err != nil || statusEffects == nil {
+		return false
+	}
+	return statusEffects.HasSuppressedAggro()
+}
+
+func hasSuppressedRetaliation(w *ecs.World, entityID common.EntityID) bool {
+	statusEffects, err := ecs.GetTypedComponent[*components.StatusEffects](w, entityID, "StatusEffects")
+	if err != nil || statusEffects == nil {
+		return false
+	}
+	return statusEffects.HasSuppressedRetaliation()
 }
 
 func isTargetDead(health *components.Health) bool {

--- a/internal/systems/status_effect.go
+++ b/internal/systems/status_effect.go
@@ -4,8 +4,7 @@ import (
 	"dmud/internal/components"
 	"dmud/internal/ecs"
 	"fmt"
-
-	"github.com/rs/zerolog/log"
+	"strings"
 )
 
 type StatusEffectSystem struct{}
@@ -34,33 +33,58 @@ func (ses *StatusEffectSystem) Update(w *ecs.World, deltaTime float64) {
 			continue
 		}
 
-		player, err := ecs.GetTypedComponent[*components.Player](w, entity.ID, "Player")
-		if err != nil {
-			continue
-		}
-
-		health, err := ecs.GetTypedComponent[*components.Health](w, entity.ID, "Health")
-		if err != nil {
-			continue
-		}
+		player, _ := ecs.GetTypedComponent[*components.Player](w, entity.ID, "Player")
+		npc, _ := ecs.GetTypedComponent[*components.NPC](w, entity.ID, "NPC")
+		health, _ := ecs.GetTypedComponent[*components.Health](w, entity.ID, "Health")
 
 		for _, effect := range removed {
-			if effect.HPBonus > 0 {
+			if effect.HPBonus > 0 && health != nil {
 				health.Lock()
 				health.Current -= effect.HPBonus
 				if health.Current < 1 {
 					health.Current = 1
 				}
 				health.Unlock()
+			}
 
-				player.Broadcast(fmt.Sprintf("The %s has worn off. (-%d HP)", effect.Name, effect.HPBonus))
-			} else {
-				player.Broadcast(fmt.Sprintf("The %s has worn off.", effect.Name))
+			if player != nil {
+				if effect.HPBonus > 0 {
+					player.Broadcast(fmt.Sprintf("The %s has worn off. (-%d HP)", effect.Name, effect.HPBonus))
+				} else {
+					player.Broadcast(fmt.Sprintf("The %s has worn off.", effect.Name))
+				}
+				continue
+			}
+
+			if npc != nil {
+				npc.RLock()
+				npcArea := npc.Area
+				npcName := npc.Name
+				npc.RUnlock()
+				if npcArea == nil {
+					continue
+				}
+
+				if effect.Type == components.StatusEffectControlledUndead {
+					npcArea.Broadcast(fmt.Sprintf("%s shudders as necromantic control fades.", npcName))
+					continue
+				}
+				if effect.Type == components.StatusEffectCharmed {
+					npcArea.Broadcast(fmt.Sprintf("%s blinks and regains free will.", npcName))
+					continue
+				}
+
+				effectName := strings.TrimSpace(strings.ToLower(effect.Name))
+				if effectName == "" {
+					effectName = "a lingering effect"
+				}
+				npcArea.Broadcast(fmt.Sprintf("%s is no longer affected by %s.", npcName, effectName))
 			}
 		}
 
-		// Always broadcast state update when effects are removed
-		log.Debug().Msgf("Broadcasting state update for %s after effect expiration", player.Name)
-		player.BroadcastState(w.AsWorldLike(), entity.ID)
+		if player != nil {
+			// Broadcast state update when player effects are removed.
+			player.BroadcastState(w.AsWorldLike(), entity.ID)
+		}
 	}
 }

--- a/resources/npcs.json
+++ b/resources/npcs.json
@@ -78,6 +78,7 @@
     "id": "skeleton",
     "name": "a shambling skeleton",
     "description": "A reanimated skeleton, its bones held together by dark magic. Empty eye sockets glow with an eerie light.",
+    "creature_type": "undead",
     "health": 60,
     "min_damage": 8,
     "max_damage": 18,


### PR DESCRIPTION
Adds creature types to NPC templates (humanoid, beast, undead), extends status effects with source tracking and aggro/retaliation suppression, and introduces a spell registry with control undead and charm spells. Controlled/charmed NPCs have their aggro suppressed in both the AI and combat systems, with flavor messages on effect expiry. Status effect persistence updated to round-trip the new fields.