### PR TITLE
Dev bootstrap: setup script, file persistence, docker compose

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -7,14 +7,14 @@ tmp_dir = "tmp"
   bin = "./bin/dmud"
   cmd = "go build -race -o ./bin/dmud -v ./cmd/dmud"
   delay = 1000
-  exclude_dir = ["assets", "tmp", "vendor", "testdata"]
+  exclude_dir = ["assets", "tmp", "vendor", "testdata", "data"]
   exclude_file = []
   exclude_regex = ["_test.go"]
   exclude_unchanged = false
   follow_symlink = false
   full_bin = ""
   include_dir = []
-  include_ext = ["go", "tpl", "tmpl", "html"]
+  include_ext = ["go", "tpl", "tmpl", "html", "json"]
   include_file = []
   kill_delay = 1000
   log = "build-errors.log"
@@ -40,5 +40,5 @@ tmp_dir = "tmp"
   clean_on_exit = false
 
 [screen]
-  clear_on_rebuild = false
+  clear_on_rebuild = true
   keep_scroll = true

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,20 @@
+# Logging: trace, debug, info, warn, error, fatal, panic
+DMUD_LOG_LEVEL=debug
+
+# WebSocket bind address
+DMUD_WS_HOST=0.0.0.0
+PORT=8080
+
+# Persistence: none, memory, file, redis
+DMUD_PERSISTENCE=none
+
+# File persistence directory (only used when DMUD_PERSISTENCE=file)
+DMUD_DATA_DIR=data
+
+# Redis (only used when DMUD_PERSISTENCE=redis)
+DMUD_REDIS_URL=redis://dmud:password@127.0.0.1:6379/0
+DMUD_PERSIST_PREFIX=dmud
+DMUD_PERSIST_TTL=24h
+
+# Admin UUIDs (comma-separated)
+DMUD_ADMIN_UUIDS=

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,8 @@
 
 *.log
 tmp/build-errors.log
+
+bin/
+tmp/
+data/
+.env

--- a/Makefile
+++ b/Makefile
@@ -4,56 +4,103 @@ IMAGE_NAME=dmud
 IMAGE_TAG?=latest
 
 GO := $(shell which go)
+AIR := $(shell go env GOPATH)/bin/air
+DOCKER_COMPOSE := docker compose
 
 default: build
+
+## setup: Install tools and dependencies (first-time setup)
+setup:
+	@bash scripts/setup.sh
 
 prep:
 	mkdir -p $(BINARY_PATH)
 
+## build: Compile binary to bin/dmud
 build: prep
 	$(GO) build -o $(BINARY_PATH)$(BINARY_NAME) -v ./cmd/dmud
 
+## dev: Start dev server with hot reload (no persistence)
+dev: prep
+	@$(AIR) -c .air.toml
+
+## dev-persist: Start dev server with file persistence (data saved to data/)
+dev-persist: prep
+	DMUD_PERSISTENCE=file DMUD_LOG_LEVEL=debug $(AIR) -c .air.toml
+
+## dev-redis: Start Redis via Docker Compose, then dev server connected to it
+dev-redis: prep
+	$(DOCKER_COMPOSE) --profile redis up -d redis
+	DMUD_PERSISTENCE=redis DMUD_LOG_LEVEL=debug $(AIR) -c .air.toml
+
+## run: Build and run locally
+run: build
+	./$(BINARY_PATH)$(BINARY_NAME)
+
+## watch: Hot-reload dev server (alias for dev)
+watch: dev
+
+## test: Run all tests
+test:
+	$(GO) test -v ./...
+
+## test-race: Run tests with race detector
+test-race:
+	$(GO) test -race -v ./...
+
+## vet: Run go vet
+vet:
+	$(GO) vet ./...
+
+## race: Run binary with race detector
+race:
+	$(GO) run -race ./cmd/dmud
+
+## clean: Remove build artifacts
 clean:
 	$(GO) clean
 	rm -rf $(BINARY_PATH)
 
-test:
-	$(GO) test -v ./...
-
-test-race:
-	$(GO) test -race -v ./...
-
-vet:
-	$(GO) vet ./...
-
+## connect: Connect to TCP server via netcat
 connect:
 	while true; do nc localhost 3333 || sleep 10; done
 
-run: build
-	./$(BINARY_PATH)$(BINARY_NAME)
-
-race:
-	$(GO) run -race ./cmd/dmud
-
-# go install github.com/air-verse/air@latest
-AIR := $(shell go env GOPATH)/bin/air
-
-watch:
-	@$(AIR) -c .air.toml
-
 # --- Docker ---
 
+## docker-build: Build Docker image
 docker-build:
 	docker build -t $(IMAGE_NAME):$(IMAGE_TAG) .
 
+## docker-run: Build and run in Docker (port 8080)
 docker-run: docker-build
 	docker run --rm -it -p 8080:8080 $(IMAGE_NAME):$(IMAGE_TAG)
 
+## docker-stop: Stop running dmud containers
 docker-stop:
 	docker stop $$(docker ps -q --filter ancestor=$(IMAGE_NAME):$(IMAGE_TAG)) 2>/dev/null || true
 
+## docker-clean: Remove dmud Docker image
 docker-clean:
 	docker rmi $(IMAGE_NAME):$(IMAGE_TAG) 2>/dev/null || true
 
-.PHONY: default prep build clean test test-race vet connect run race watch \
-	docker-build docker-run docker-stop docker-clean
+# --- Docker Compose ---
+
+## dc-up: Start services via Docker Compose
+dc-up:
+	$(DOCKER_COMPOSE) up --build
+
+## dc-down: Stop Docker Compose services
+dc-down:
+	$(DOCKER_COMPOSE) down
+
+## dc-logs: Tail Docker Compose logs
+dc-logs:
+	$(DOCKER_COMPOSE) logs -f
+
+## help: Show available targets
+help:
+	@grep -E '^## ' $(MAKEFILE_LIST) | sed 's/^## //' | column -t -s ':'
+
+.PHONY: default setup prep build dev dev-persist dev-redis run watch test test-race vet race clean connect \
+	docker-build docker-run docker-stop docker-clean \
+	dc-up dc-down dc-logs help

--- a/README.md
+++ b/README.md
@@ -1,37 +1,66 @@
-# What is this?
+# dmud
 
-Hey y'all, i've been trying to get better w/ go and this is that!
+A MUD game server written in Go using an ECS architecture.
 
-I went w/ a very standard ECS pattern and I've been experimenting w/ using AI agents to implement some features w/ ~some, lol, success
+Client: [https://dusty.wtf/projects/dmud/](https://dusty.wtf/projects/dmud/)
 
-Deploys happen on push via Cloud Build and I have a very basic client talking via websockets here
+## Quick Start
 
-[https://dusty.wtf/projects/dmud/](https://dusty.wtf/projects/dmud/)
+```bash
+# First-time setup (installs tools, downloads deps)
+make setup
 
-# ...
+# Start dev server with hot reload
+make dev
 
+# Run tests
+make test
 ```
-find internal -type f -name '*.go' -exec sh -c 'echo "=== {} ==="; cat {}' \;
-```
+
+## All Targets
+
+Run `make help` to see the full list, or:
 
 | Target | What it does |
 |---|---|
-| `make` | Build the binary to `bin/dmud` |
+| `make setup` | Install tools and dependencies (first-time) |
+| `make dev` | Start dev server with hot reload |
+| `make build` | Compile binary to `bin/dmud` |
 | `make run` | Build and run locally |
-| `make watch` | Hot-reload dev server (requires `air`) |
-| `make test` | Run tests |
+| `make test` | Run all tests |
 | `make test-race` | Run tests with race detector |
 | `make vet` | Run `go vet` |
-| `make race` | Run with race detector |
+| `make race` | Run binary with race detector |
 | `make clean` | Remove build artifacts |
-| `make docker-build` | Build Docker image (`dmud:latest`) |
+| `make docker-build` | Build Docker image |
 | `make docker-run` | Build and run in Docker (port 8080) |
 | `make docker-stop` | Stop running dmud containers |
-| `make docker-clean` | Remove the dmud image |
+| `make docker-clean` | Remove dmud Docker image |
+| `make dc-up` | Start via Docker Compose |
+| `make dc-down` | Stop Docker Compose services |
+| `make dc-logs` | Tail Docker Compose logs |
 
+## Docker
 
+```bash
+# Run production image locally
+make dc-up
 
+# Run with Redis persistence
+DMUD_PERSISTENCE=redis docker compose --profile redis up --build
+```
 
+## Environment Variables
 
+See [`.env.example`](.env.example) for all options. Key ones:
 
+| Variable | Default | Description |
+|---|---|---|
+| `DMUD_LOG_LEVEL` | `info` | Log level (debug, info, warn, error) |
+| `PORT` | `8080` | WebSocket server port |
+| `DMUD_PERSISTENCE` | `none` | Persistence driver (none, redis) |
+| `DMUD_REDIS_URL` | `redis://...localhost:6379/0` | Redis connection URL |
 
+## Architecture
+
+ECS (Entity Component System) pattern with a ~100Hz game loop. See [AGENT.md](AGENT.md) for the full architecture deep-dive.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,27 @@
+services:
+  dmud:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "8080:8080"
+    environment:
+      - DMUD_LOG_LEVEL=debug
+      - DMUD_PERSISTENCE=${DMUD_PERSISTENCE:-none}
+      - DMUD_REDIS_URL=redis://dmud:password@redis:6379/0
+      - PORT=8080
+    volumes:
+      - ./resources:/app/resources
+    depends_on:
+      redis:
+        condition: service_started
+        required: false
+    restart: unless-stopped
+
+  redis:
+    image: redis:7-alpine
+    command: redis-server --requirepass password
+    ports:
+      - "6379:6379"
+    profiles:
+      - redis

--- a/internal/persistence/factory.go
+++ b/internal/persistence/factory.go
@@ -13,8 +13,10 @@ const (
 	envRedisURL2     = "REDIS_URL"
 	envKeyPrefix     = "DMUD_PERSIST_PREFIX"
 	envTTL           = "DMUD_PERSIST_TTL"
+	envDataDir       = "DMUD_DATA_DIR"
 	defaultRedisURL  = "redis://dmud:password@127.0.0.1:6379/0"
 	defaultKeyPrefix = "dmud"
+	defaultDataDir   = "data"
 )
 
 func NewStoreFromEnv() (Store, error) {
@@ -27,6 +29,7 @@ func NewStoreFromEnv() (Store, error) {
 		Driver:    driver,
 		RedisURL:  firstNonEmpty(os.Getenv(envRedisURL), os.Getenv(envRedisURL2)),
 		KeyPrefix: os.Getenv(envKeyPrefix),
+		DataDir:   os.Getenv(envDataDir),
 		TTL:       0,
 	}
 
@@ -56,6 +59,12 @@ func NewStore(config StoreConfig) (Store, error) {
 			KeyPrefix: config.KeyPrefix,
 			TTL:       config.TTL,
 		})
+	case "file":
+		dir := config.DataDir
+		if dir == "" {
+			dir = defaultDataDir
+		}
+		return NewFileStore(dir)
 	case "memory":
 		return NewMemoryStore(), nil
 	case "none", "off", "":

--- a/internal/persistence/file_store.go
+++ b/internal/persistence/file_store.go
@@ -1,0 +1,170 @@
+package persistence
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+type FileStore struct {
+	mu  sync.RWMutex
+	dir string
+}
+
+func NewFileStore(dir string) (*FileStore, error) {
+	if dir == "" {
+		dir = "data"
+	}
+	playersDir := filepath.Join(dir, "players")
+	if err := os.MkdirAll(playersDir, 0755); err != nil {
+		return nil, err
+	}
+	return &FileStore{dir: dir}, nil
+}
+
+func (f *FileStore) LoadPlayer(_ context.Context, key string) (*PlayerState, error) {
+	if key == "" {
+		return nil, nil
+	}
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+
+	data, err := os.ReadFile(f.playerPath(key))
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	var state PlayerState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return nil, err
+	}
+	return &state, nil
+}
+
+func (f *FileStore) SavePlayer(_ context.Context, key string, state *PlayerState) error {
+	if key == "" || state == nil {
+		return nil
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return f.writeJSON(f.playerPath(key), state)
+}
+
+func (f *FileStore) DeletePlayer(_ context.Context, key string) error {
+	if key == "" {
+		return nil
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	err := os.Remove(f.playerPath(key))
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	return err
+}
+
+func (f *FileStore) LoadWorld(_ context.Context) (*WorldState, error) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+
+	data, err := os.ReadFile(f.worldPath())
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	var state WorldState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return nil, err
+	}
+	return &state, nil
+}
+
+func (f *FileStore) SaveWorld(_ context.Context, state *WorldState) error {
+	if state == nil {
+		return nil
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return f.writeJSON(f.worldPath(), state)
+}
+
+func (f *FileStore) IsAdmin(_ context.Context, key string) (bool, error) {
+	if key == "" {
+		return false, nil
+	}
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+
+	admins, _ := f.loadAdmins()
+	return admins[key], nil
+}
+
+func (f *FileStore) SetAdmin(_ context.Context, key string, isAdmin bool) error {
+	if key == "" {
+		return nil
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	admins, _ := f.loadAdmins()
+	if admins == nil {
+		admins = make(map[string]bool)
+	}
+	if isAdmin {
+		admins[key] = true
+	} else {
+		delete(admins, key)
+	}
+	return f.writeJSON(f.adminsPath(), admins)
+}
+
+// writeJSON atomically writes JSON data to a file using a temp file + rename.
+func (f *FileStore) writeJSON(path string, v any) error {
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+func (f *FileStore) loadAdmins() (map[string]bool, error) {
+	data, err := os.ReadFile(f.adminsPath())
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var admins map[string]bool
+	err = json.Unmarshal(data, &admins)
+	return admins, err
+}
+
+func (f *FileStore) playerPath(key string) string {
+	return filepath.Join(f.dir, "players", key+".json")
+}
+
+func (f *FileStore) worldPath() string {
+	return filepath.Join(f.dir, "world.json")
+}
+
+func (f *FileStore) adminsPath() string {
+	return filepath.Join(f.dir, "admins.json")
+}

--- a/internal/persistence/store.go
+++ b/internal/persistence/store.go
@@ -22,6 +22,7 @@ type StoreConfig struct {
 	RedisURL  string
 	KeyPrefix string
 	TTL       time.Duration
+	DataDir   string
 }
 
 type PlayerState struct {

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+info()  { echo -e "${BOLD}$1${NC}"; }
+ok()    { echo -e "  ${GREEN}✓${NC} $1"; }
+warn()  { echo -e "  ${YELLOW}!${NC} $1"; }
+fail()  { echo -e "  ${RED}✗${NC} $1"; }
+
+info "Setting up dmud development environment..."
+echo
+
+# --- Go ---
+if ! command -v go &>/dev/null; then
+    fail "Go is not installed."
+    echo "    Install Go 1.22+: https://go.dev/dl/"
+    exit 1
+fi
+
+GO_VERSION=$(go version | grep -oE 'go[0-9]+\.[0-9]+' | head -1 | sed 's/go//')
+GO_MAJOR=$(echo "$GO_VERSION" | cut -d. -f1)
+GO_MINOR=$(echo "$GO_VERSION" | cut -d. -f2)
+
+if [ "$GO_MAJOR" -lt 1 ] || { [ "$GO_MAJOR" -eq 1 ] && [ "$GO_MINOR" -lt 22 ]; }; then
+    fail "Go $GO_VERSION found, but 1.22+ is required."
+    echo "    Upgrade: https://go.dev/dl/"
+    exit 1
+fi
+ok "Go $GO_VERSION"
+
+# --- Dependencies ---
+info "Downloading Go modules..."
+go mod download
+ok "Dependencies downloaded"
+
+# --- Air (live reload) ---
+AIR_PATH="$(go env GOPATH)/bin/air"
+if [ -x "$AIR_PATH" ]; then
+    ok "air already installed"
+else
+    info "Installing air (live reload)..."
+    go install github.com/air-verse/air@latest
+    ok "air installed"
+fi
+
+# --- Directories ---
+mkdir -p bin tmp
+ok "Created bin/ and tmp/ directories"
+
+# --- Docker (optional) ---
+echo
+if command -v docker &>/dev/null; then
+    ok "Docker found (optional, used for make dc-up)"
+else
+    warn "Docker not found (optional, only needed for make dc-up)"
+fi
+
+# --- Summary ---
+echo
+echo -e "${GREEN}${BOLD}Setup complete!${NC}"
+echo
+echo "  Get started:"
+echo "    make dev        Start dev server with hot reload"
+echo "    make test       Run tests"
+echo "    make build      Build binary"
+echo
+echo "  Environment variables (see .env.example):"
+echo "    DMUD_LOG_LEVEL=debug    Verbose logging"
+echo "    DMUD_PERSISTENCE=redis  Enable Redis persistence"
+echo


### PR DESCRIPTION
## Summary
- **Bootstrap script** (`scripts/setup.sh`): checks Go version, installs `air` for hot reload, downloads deps — one command to get started
- **File persistence backend** (`DMUD_PERSISTENCE=file`): writes player/world state as JSON to `data/`, no external deps needed for local dev with persistence
- **Docker Compose**: game server + opt-in Redis (`--profile redis`), resource volume mounts
- **Makefile targets**: `make setup`, `make dev`, `make dev-persist`, `make dev-redis`, `make help`
- **DX polish**: `.env.example` documenting all env vars, `.air.toml` watches JSON resource files, README quickstart

## Test plan
- [ ] `make setup` runs clean on fresh clone
- [ ] `make dev` starts server with hot reload, no restart loop
- [ ] `make dev-persist` saves state to `data/` that survives restart
- [ ] `docker compose up --build` starts game server
- [ ] `make help` lists all targets